### PR TITLE
add buildbot push logic

### DIFF
--- a/modules/icebox/databases.nix
+++ b/modules/icebox/databases.nix
@@ -1,0 +1,143 @@
+# Pre-configured bioinformatics databases
+{ pkgs, lib, ... }:
+{
+  services.icebox.databases = {
+    # NCBI BLAST databases
+    # https://ftp.ncbi.nlm.nih.gov/blast/db/
+    blast-nr = {
+      enable = lib.mkDefault false;
+      syncMethod = "script";
+      syncScript = ''
+        ${pkgs.blast}/bin/update_blastdb.pl --decompress --passive nr
+      '';
+      schedule = lib.mkDefault "weekly";
+    };
+
+    blast-nt = {
+      enable = lib.mkDefault false;
+      syncMethod = "script";
+      syncScript = ''
+        ${pkgs.blast}/bin/update_blastdb.pl --decompress --passive nt
+      '';
+      schedule = lib.mkDefault "weekly";
+    };
+
+    blast-refseq-protein = {
+      enable = lib.mkDefault false;
+      syncMethod = "script";
+      syncScript = ''
+        ${pkgs.blast}/bin/update_blastdb.pl --decompress --passive refseq_protein
+      '';
+      schedule = lib.mkDefault "weekly";
+    };
+
+    blast-swissprot = {
+      enable = lib.mkDefault false;
+      syncMethod = "script";
+      syncScript = ''
+        ${pkgs.blast}/bin/update_blastdb.pl --decompress --passive swissprot
+      '';
+      schedule = lib.mkDefault "weekly";
+    };
+
+    # UniProt Reference Clusters
+    # https://ftp.uniprot.org/pub/databases/uniprot/uniref/
+    uniref90 = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/";
+      syncMethod = "rsync";
+      syncArgs = [
+        "--delete"
+        "--include=uniref90.fasta.gz"
+        "--include=uniref90.xml.gz"
+        "--exclude=*"
+      ];
+      schedule = lib.mkDefault "monthly";
+    };
+
+    uniref100 = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref100/";
+      syncMethod = "rsync";
+      syncArgs = [
+        "--delete"
+        "--include=uniref100.fasta.gz"
+        "--include=uniref100.xml.gz"
+        "--exclude=*"
+      ];
+      schedule = lib.mkDefault "monthly";
+    };
+
+    # Protein Data Bank (PDB)
+    # https://www.wwpdb.org/ftp/pdb-ftp-sites
+    pdb = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://rsync.rcsb.org/ftp_data/structures/divided/pdb/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "weekly";
+    };
+
+    # PDB in mmCIF format
+    pdb-mmcif = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://rsync.rcsb.org/ftp_data/structures/divided/mmCIF/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "weekly";
+    };
+
+    # RNAcentral
+    # https://rnacentral.org/downloads
+    rnacentral = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "monthly";
+    };
+
+    # AlphaFold Database (requires rclone with GCS)
+    # https://alphafold.ebi.ac.uk/download
+    alphafold = {
+      enable = lib.mkDefault false;
+      syncUrl = "gs://public-datasets-deepmind-alphafold-v4";
+      syncMethod = "rclone";
+      syncArgs = [
+        "--transfers=8"
+        "--checkers=8"
+      ];
+      schedule = lib.mkDefault "quarterly"; # Very large, sync less frequently
+    };
+
+    # Pfam
+    # https://www.ebi.ac.uk/interpro/download/pfam/
+    pfam = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "monthly";
+    };
+
+    # Rfam (RNA families)
+    # https://rfam.org/
+    rfam = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "monthly";
+    };
+
+    # InterPro
+    # https://www.ebi.ac.uk/interpro/download/
+    interpro = {
+      enable = lib.mkDefault false;
+      syncUrl = "rsync://ftp.ebi.ac.uk/pub/databases/interpro/current_release/";
+      syncMethod = "rsync";
+      syncArgs = [ "--delete" ];
+      schedule = lib.mkDefault "monthly";
+    };
+  };
+}

--- a/modules/icebox/default.nix
+++ b/modules/icebox/default.nix
@@ -1,0 +1,168 @@
+# icebox - Database sync and snapshot management
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.icebox;
+
+  databaseModule = lib.types.submodule {
+    options = {
+      enable = lib.mkEnableOption "this database";
+
+      syncUrl = lib.mkOption {
+        type = lib.types.str;
+        description = "URL to sync from (rsync://, gs://, https://, etc.)";
+      };
+
+      syncMethod = lib.mkOption {
+        type = lib.types.enum [
+          "rsync"
+          "rclone"
+          "wget"
+          "script"
+        ];
+        default = "rsync";
+        description = "Sync method to use";
+      };
+
+      syncArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Additional arguments for sync command";
+      };
+
+      syncScript = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
+        default = null;
+        description = "Custom sync script (when syncMethod = script)";
+      };
+
+      schedule = lib.mkOption {
+        type = lib.types.str;
+        default = "monthly";
+        description = "Systemd calendar schedule (weekly, monthly, *-*-01, etc.)";
+      };
+
+      postSync = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = "Commands to run after successful sync";
+      };
+    };
+  };
+
+  # Generate sync command for a database
+  mkSyncCommand =
+    name: db:
+    let
+      destDir = "${cfg.root}/${name}";
+    in
+    if db.syncMethod == "script" then
+      db.syncScript
+    else if db.syncMethod == "rsync" then
+      ''
+        ${pkgs.rsync}/bin/rsync -avz --progress ${lib.concatStringsSep " " db.syncArgs} \
+          "${db.syncUrl}" "${destDir}/"
+      ''
+    else if db.syncMethod == "rclone" then
+      ''
+        ${pkgs.rclone}/bin/rclone sync ${lib.concatStringsSep " " db.syncArgs} \
+          "${db.syncUrl}" "${destDir}" --progress
+      ''
+    else if db.syncMethod == "wget" then
+      ''
+        ${pkgs.wget}/bin/wget -N -P "${destDir}" ${lib.concatStringsSep " " db.syncArgs} \
+          "${db.syncUrl}"
+      ''
+    else
+      throw "Unknown sync method: ${db.syncMethod}";
+
+  # Filter enabled databases
+  enabledDatabases = lib.filterAttrs (_: db: db.enable) cfg.databases;
+in
+{
+  options.services.icebox = {
+    enable = lib.mkEnableOption "icebox database manager";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.python3.pkgs.callPackage ../../packages/icebox { };
+      description = "icebox package to use";
+    };
+
+    root = lib.mkOption {
+      type = lib.types.path;
+      default = "/workspace/shared/databases";
+      description = "Root directory for databases";
+    };
+
+    databases = lib.mkOption {
+      type = lib.types.attrsOf databaseModule;
+      default = { };
+      description = "Database configurations";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Install icebox CLI
+    environment.systemPackages = [ cfg.package ];
+
+    # Create database directories
+    systemd.tmpfiles.rules = [
+      "d ${cfg.root} 0755 root users -"
+    ]
+    ++ (lib.mapAttrsToList (name: _: "d ${cfg.root}/${name} 0755 root users -") enabledDatabases);
+
+    # Generate sync services
+    systemd.services = lib.mapAttrs' (
+      name: db:
+      lib.nameValuePair "icebox-sync-${name}" {
+        description = "Sync ${name} database";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          Nice = 19;
+          IOSchedulingClass = "idle";
+          TimeoutStartSec = "24h";
+        };
+
+        path = [ pkgs.coreutils ];
+
+        script = ''
+          set -euo pipefail
+          echo "Starting sync for ${name}..."
+          cd "${cfg.root}/${name}"
+
+          ${mkSyncCommand name db}
+
+          ${lib.optionalString (db.postSync != "") ''
+            echo "Running post-sync commands..."
+            ${db.postSync}
+          ''}
+
+          echo "Sync completed for ${name}"
+        '';
+      }
+    ) enabledDatabases;
+
+    # Generate timers
+    systemd.timers = lib.mapAttrs' (
+      name: db:
+      lib.nameValuePair "icebox-sync-${name}" {
+        description = "Timer for ${name} database sync";
+        wantedBy = [ "timers.target" ];
+
+        timerConfig = {
+          OnCalendar = db.schedule;
+          Persistent = true;
+          RandomizedDelaySec = "1h";
+        };
+      }
+    ) enabledDatabases;
+  };
+}

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -1,12 +1,18 @@
-{self, ...}: {
-  perSystem = {
-    pkgs,
-    lib,
-    ...
-  }: {
-    packages = lib.optionalAttrs pkgs.stdenv.isLinux {
-      installer = pkgs.callPackage ./image-installer {inherit pkgs self;};
-      kexec = pkgs.callPackage ./kexec-installer.nix {inherit pkgs self;};
+{ self, ... }:
+{
+  perSystem =
+    {
+      pkgs,
+      lib,
+      ...
+    }:
+    {
+      packages = {
+        icebox = pkgs.python3.pkgs.callPackage ./icebox { };
+      }
+      // lib.optionalAttrs pkgs.stdenv.isLinux {
+        installer = pkgs.callPackage ./image-installer { inherit pkgs self; };
+        kexec = pkgs.callPackage ./kexec-installer { inherit pkgs self; };
+      };
     };
-  };
 }

--- a/packages/icebox/default.nix
+++ b/packages/icebox/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonApplication,
+  hatchling,
+  click,
+  makeWrapper,
+  rsync,
+  rclone,
+  wget,
+}:
+let
+  runtimeDeps = [
+    rsync
+    rclone
+    wget
+  ];
+in
+buildPythonApplication {
+  pname = "icebox";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [ hatchling ];
+  dependencies = [ click ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/icebox \
+      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+  '';
+
+  meta = {
+    description = "Keep databases fresh, freeze when needed";
+    mainProgram = "icebox";
+  };
+}

--- a/packages/icebox/icebox/__init__.py
+++ b/packages/icebox/icebox/__init__.py
@@ -1,0 +1,3 @@
+"""icebox - Keep databases fresh, freeze when needed."""
+
+__version__ = "0.1.0"

--- a/packages/icebox/icebox/cli.py
+++ b/packages/icebox/icebox/cli.py
@@ -1,0 +1,84 @@
+"""CLI interface for icebox."""
+
+from pathlib import Path
+
+import click
+
+from . import db
+
+
+@click.group()
+@click.option(
+    "--root",
+    type=click.Path(exists=True, path_type=Path),
+    default="/workspace/shared/databases",
+    envvar="ICEBOX_ROOT",
+    help="Database root directory",
+)
+@click.pass_context
+def main(ctx: click.Context, root: Path) -> None:
+    """Keep databases fresh, freeze when needed."""
+    ctx.ensure_object(dict)
+    ctx.obj["root"] = root
+
+
+@main.command("list")
+@click.option("--frozen", is_flag=True, help="List frozen snapshots only")
+@click.argument("database", required=False)
+@click.pass_context
+def list_cmd(ctx: click.Context, frozen: bool, database: str | None) -> None:
+    """List databases or frozen snapshots."""
+    root = ctx.obj["root"]
+
+    if frozen:
+        snapshots = db.list_frozen(root, database)
+        if not snapshots:
+            click.echo("No frozen snapshots found.")
+            return
+        for s in snapshots:
+            click.echo(f"{s.source}.frozen.{s.tag}\t{s.size}\t{s.created}")
+    else:
+        databases = db.list_databases(root)
+        if not databases:
+            click.echo("No databases found.")
+            return
+        for d in databases:
+            click.echo(f"{d.name}\t{d.size}\t{d.updated}")
+
+
+@main.command()
+@click.argument("database")
+@click.argument("tag")
+@click.pass_context
+def freeze(ctx: click.Context, database: str, tag: str) -> None:
+    """Create a frozen snapshot of a database."""
+    root = ctx.obj["root"]
+    path = db.freeze(root, database, tag)
+    click.echo(f"Frozen: {path}")
+
+
+@main.command()
+@click.argument("database")
+@click.argument("tag")
+@click.pass_context
+def thaw(ctx: click.Context, database: str, tag: str) -> None:
+    """Remove a frozen snapshot."""
+    root = ctx.obj["root"]
+    db.thaw(root, database, tag)
+    click.echo(f"Thawed: {database}.frozen.{tag}")
+
+
+@main.command()
+@click.argument("database")
+@click.argument("url")
+@click.option("--method", type=click.Choice(["rsync", "rclone", "wget"]), default="rsync")
+@click.pass_context
+def sync(ctx: click.Context, database: str, url: str, method: str) -> None:
+    """Sync database from remote source."""
+    root = ctx.obj["root"]
+    db.sync(root, database, url, method)
+    click.echo(f"Synced: {database}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/icebox/icebox/db.py
+++ b/packages/icebox/icebox/db.py
@@ -1,0 +1,137 @@
+"""Database operations."""
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+
+@dataclass
+class Database:
+    name: str
+    path: Path
+    size: str
+    updated: str
+
+
+@dataclass
+class Snapshot:
+    source: str
+    tag: str
+    path: Path
+    size: str
+    created: str
+
+
+def list_databases(root: Path) -> list[Database]:
+    """List all live databases (non-frozen directories)."""
+    databases = []
+    for p in sorted(root.iterdir()):
+        if not p.is_dir() or ".frozen." in p.name:
+            continue
+        databases.append(
+            Database(
+                name=p.name,
+                path=p,
+                size=_dir_size(p),
+                updated=_mtime(p),
+            )
+        )
+    return databases
+
+
+def list_frozen(root: Path, filter_db: str | None = None) -> list[Snapshot]:
+    """List frozen snapshots, optionally filtered by database name."""
+    snapshots = []
+    for p in sorted(root.iterdir()):
+        if not p.is_dir() or ".frozen." not in p.name:
+            continue
+        parts = p.name.split(".frozen.", 1)
+        if len(parts) != 2:
+            continue
+        source, tag = parts
+        if filter_db and source != filter_db:
+            continue
+        snapshots.append(
+            Snapshot(
+                source=source,
+                tag=tag,
+                path=p,
+                size=_dir_size(p),
+                created=_mtime(p),
+            )
+        )
+    return snapshots
+
+
+def freeze(root: Path, database: str, tag: str) -> Path:
+    """Create a reflink copy of a database."""
+    src = root / database
+    dst = root / f"{database}.frozen.{tag}"
+
+    if not src.exists():
+        raise click.ClickException(f"Database not found: {database}")
+    if dst.exists():
+        raise click.ClickException(f"Snapshot already exists: {dst.name}")
+
+    # Use cp --reflink for CoW copy (XFS/Btrfs)
+    subprocess.run(
+        ["cp", "--reflink=auto", "-a", str(src), str(dst)],
+        check=True,
+    )
+    return dst
+
+
+def thaw(root: Path, database: str, tag: str) -> None:
+    """Remove a frozen snapshot."""
+    path = root / f"{database}.frozen.{tag}"
+    if not path.exists():
+        raise click.ClickException(f"Snapshot not found: {path.name}")
+    shutil.rmtree(path)
+
+
+def sync(root: Path, database: str, url: str, method: str) -> None:
+    """Sync database from remote URL."""
+    dst = root / database
+    dst.mkdir(parents=True, exist_ok=True)
+
+    if method == "rsync":
+        subprocess.run(
+            ["rsync", "-avz", "--progress", url, str(dst) + "/"],
+            check=True,
+        )
+    elif method == "rclone":
+        subprocess.run(
+            ["rclone", "sync", url, str(dst), "--progress"],
+            check=True,
+        )
+    elif method == "wget":
+        subprocess.run(
+            ["wget", "-N", "-P", str(dst), url],
+            check=True,
+        )
+
+
+def _dir_size(path: Path) -> str:
+    """Get human-readable directory size."""
+    try:
+        result = subprocess.run(
+            ["du", "-sh", str(path)],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.split()[0]
+    except Exception:
+        return "?"
+
+
+def _mtime(path: Path) -> str:
+    """Get modification time as date string."""
+    try:
+        ts = path.stat().st_mtime
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+    except Exception:
+        return "?"

--- a/packages/icebox/pyproject.toml
+++ b/packages/icebox/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "icebox"
+version = "0.1.0"
+description = "Keep databases fresh, freeze when needed"
+requires-python = ">=3.11"
+dependencies = ["click>=8.0"]
+
+[project.scripts]
+icebox = "icebox.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/packages/image-installer/base-config.nix
+++ b/packages/image-installer/base-config.nix
@@ -2,11 +2,13 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   mulattaKeys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkKJdIzvxlWcry+brNiCGLBNkxrMxFDyo1anE4xRNkL"
   ];
-in {
+in
+{
   system.stateVersion = "25.05";
 
   networking.firewall.enable = false;
@@ -17,7 +19,7 @@ in {
 
   services.openssh = {
     enable = true;
-    ports = [10022];
+    ports = [ 10022 ];
     settings = {
       PermitRootLogin = "yes";
     };
@@ -38,5 +40,5 @@ in {
     jq
   ];
 
-  systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
+  systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
 }

--- a/packages/image-installer/default.nix
+++ b/packages/image-installer/default.nix
@@ -2,7 +2,8 @@
   self,
   pkgs,
   ...
-}: let
+}:
+let
   commonModule = {
     imports = [
       ./base-config.nix
@@ -12,8 +13,8 @@
     _module.args.inputs = self.inputs;
   };
 in
-  self.inputs.nixos-generators.nixosGenerate {
-    inherit pkgs;
-    format = "install-iso";
-    modules = [commonModule];
-  }
+self.inputs.nixos-generators.nixosGenerate {
+  inherit pkgs;
+  format = "install-iso";
+  modules = [ commonModule ];
+}


### PR DESCRIPTION
Add icebox tool for managing bioinformatics databases:

CLI (packages/icebox):
- list: show live databases
- list --frozen: show frozen snapshots
- freeze <db> <tag>: create reflink snapshot
- thaw <db> <tag>: remove snapshot
- sync <db> <url>: sync from remote

NixOS module (modules/icebox):
- services.icebox.enable
- services.icebox.databases.<name>.enable
- Generates systemd services and timers per database
- Pre-configured databases: BLAST, UniRef, PDB, RNAcentral, etc.

Enabled on psi: blast-nr, blast-nt, blast-swissprot, uniref90,
uniref100, pdb, pdb-mmcif, rnacentral, pfam, rfam
