### PR TITLE
hardening headscale network policy

### DIFF
--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -51,6 +51,12 @@
 
       logtail.enabled = false;
       metrics_listen_addr = "127.0.0.1:9090";
+
+      # ACL policy: admins get full access, researchers/students get service ports only
+      policy = {
+        mode = "file";
+        path = ./policy.json;
+      };
     };
   };
 

--- a/modules/headscale/policy.json
+++ b/modules/headscale/policy.json
@@ -1,0 +1,26 @@
+{
+  "groups": {
+    "group:admins": ["sjanglab-admins@"],
+    "group:researchers": ["sjanglab-researchers@"],
+    "group:students": ["sjanglab-students@"]
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["group:admins"],
+      "dst": ["*:*"]
+    },
+    {
+      "action": "accept",
+      "src": ["group:researchers", "group:students"],
+      "proto": "tcp",
+      "dst": ["*:80", "*:443"]
+    },
+    {
+      "action": "accept",
+      "src": ["autogroup:member"],
+      "dst": ["autogroup:self:*"]
+    }
+  ],
+  "ssh": []
+}

--- a/modules/sshd/default.nix
+++ b/modules/sshd/default.nix
@@ -4,11 +4,10 @@
   ...
 }:
 let
-  cfg = config.networking.sbee.currentHost;
   cert = ./certs + "/${config.networking.hostName}-cert.pub";
 
-  # ========== Nodes ==========
-  isPublicNode = builtins.elem "public-ip" cfg.tags;
+  # eta is the only bastion host (SSH exposed to internet)
+  isBastion = config.networking.hostName == "eta";
 
   otherPublicIPs = lib.mapAttrsToList (_name: host: host.ipv4) (
     lib.filterAttrs (_name: host: builtins.elem "public-ip" host.tags) config.networking.sbee.others
@@ -16,50 +15,47 @@ let
 
   hasWhitelist = otherPublicIPs != [ ];
 
-  # ========== Constants ==========
-  security = {
-    ssh = {
-      port = 10022;
-      maxAuthTries = 3;
-      maxAuthTriesExternal = 2;
-      loginGraceTime = 30;
-      clientAliveInterval = 1200;
-      clientAliveCountMax = 3;
-    };
+  ssh = {
+    port = 10022;
+    maxAuthTries = 3;
+    loginGraceTime = 30;
+    clientAliveInterval = 1200;
+    clientAliveCountMax = 3;
+  };
 
-    fail2ban = {
-      maxRetry = 3;
-      findTime = 600;
-      banTime = 86400;
-      aggressiveBanTime = 604800;
-    };
+  fail2ban = {
+    maxRetry = 3;
+    findTime = 600;
+    banTime = 86400;
+    aggressiveBanTime = 604800;
+  };
 
-    rateLimiting = {
-      timeWindow = 60;
-      maxAttempts = 5;
-    };
+  rateLimiting = {
+    timeWindow = 60;
+    maxAttempts = 5;
   };
 in
 {
-  # ========== SSH services ==========
+  # ========== SSH server ==========
   services.openssh = {
     enable = true;
-    ports = [ security.ssh.port ];
+    ports = [ ssh.port ];
+    openFirewall = false; # We manage firewall rules manually based on bastion role
 
     settings = {
       X11Forwarding = false;
       PubkeyAuthentication = true;
       PermitEmptyPasswords = false;
 
-      MaxAuthTries = security.ssh.maxAuthTries;
-      LoginGraceTime = security.ssh.loginGraceTime;
+      MaxAuthTries = ssh.maxAuthTries;
+      LoginGraceTime = ssh.loginGraceTime;
 
       PermitUserEnvironment = false;
       Compression = false;
 
       TCPKeepAlive = true;
-      ClientAliveInterval = security.ssh.clientAliveInterval;
-      ClientAliveCountMax = security.ssh.clientAliveCountMax;
+      ClientAliveInterval = ssh.clientAliveInterval;
+      ClientAliveCountMax = ssh.clientAliveCountMax;
 
       Ciphers = [
         "chacha20-poly1305@openssh.com"
@@ -93,7 +89,7 @@ in
     '';
   };
 
-  # ========== SSH CA  ==========
+  # ========== SSH CA ==========
   warnings = lib.optional (
     !builtins.pathExists cert && config.networking.hostName != "nixos"
   ) "No ssh certificate found at ${toString cert}";
@@ -104,10 +100,10 @@ in
     publicKeyFile = ./certs/ssh-ca.pub;
   };
 
-  # ========== fail2ban (for only public IP nodes) ==========
-  services.fail2ban = lib.mkIf isPublicNode {
+  # ========== fail2ban (bastion only) ==========
+  services.fail2ban = lib.mkIf isBastion {
     enable = true;
-    maxretry = security.fail2ban.maxRetry;
+    maxretry = fail2ban.maxRetry;
 
     ignoreIP = [
       "127.0.0.1/8"
@@ -120,11 +116,11 @@ in
       sshd = {
         settings = {
           enabled = true;
-          inherit (security.ssh) port;
+          inherit (ssh) port;
           filter = "sshd";
-          maxretry = security.fail2ban.maxRetry;
-          findtime = security.fail2ban.findTime;
-          bantime = security.fail2ban.banTime;
+          maxretry = fail2ban.maxRetry;
+          findtime = fail2ban.findTime;
+          bantime = fail2ban.banTime;
           backend = "systemd";
         };
       };
@@ -132,52 +128,63 @@ in
       sshd-aggressive = {
         settings = {
           enabled = true;
-          inherit (security.ssh) port;
+          inherit (ssh) port;
           filter = "sshd[mode=aggressive]";
           maxretry = 1;
-          findtime = security.fail2ban.banTime;
-          bantime = security.fail2ban.aggressiveBanTime;
+          findtime = fail2ban.banTime;
+          bantime = fail2ban.aggressiveBanTime;
           backend = "systemd";
         };
       };
     };
   };
 
-  # ========== firewall with rate limiting ==========
+  # ========== firewall ==========
+  # Bastion: SSH exposed to internet with rate limiting
+  # Non-bastion: SSH only via WireGuard (wg-admin)
   networking.firewall = {
     enable = true;
-    allowedTCPPorts = [ security.ssh.port ];
+  }
+  // (
+    if isBastion then
+      {
+        allowedTCPPorts = [ ssh.port ];
 
-    extraCommands = lib.optionalString isPublicNode ''
-      ${lib.optionalString hasWhitelist ''
-        ${lib.concatMapStringsSep "\n" (ip: ''
-          iptables -I INPUT -s ${ip} -p tcp --dport ${toString security.ssh.port} -j ACCEPT
-        '') otherPublicIPs}
-      ''}
+        extraCommands = ''
+          ${lib.optionalString hasWhitelist ''
+            ${lib.concatMapStringsSep "\n" (ip: ''
+              iptables -I INPUT -s ${ip} -p tcp --dport ${toString ssh.port} -j ACCEPT
+            '') otherPublicIPs}
+          ''}
 
-      iptables -A INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString security.ssh.port} \
-        -m state --state NEW -m recent --set --name SSH
-      iptables -A INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString security.ssh.port} \
-        -m state --state NEW -m recent --update \
-        --seconds ${toString security.rateLimiting.timeWindow} \
-        --hitcount ${toString security.rateLimiting.maxAttempts} \
-        --name SSH -j DROP
-    '';
+          iptables -A INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString ssh.port} \
+            -m state --state NEW -m recent --set --name SSH
+          iptables -A INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString ssh.port} \
+            -m state --state NEW -m recent --update \
+            --seconds ${toString rateLimiting.timeWindow} \
+            --hitcount ${toString rateLimiting.maxAttempts} \
+            --name SSH -j DROP
+        '';
 
-    extraStopCommands = lib.optionalString isPublicNode ''
-      ${lib.optionalString hasWhitelist ''
-        ${lib.concatMapStringsSep "\n" (ip: ''
-          iptables -D INPUT -s ${ip} -p tcp --dport ${toString security.ssh.port} -j ACCEPT 2>/dev/null || true
-        '') otherPublicIPs}
-      ''}
+        extraStopCommands = ''
+          ${lib.optionalString hasWhitelist ''
+            ${lib.concatMapStringsSep "\n" (ip: ''
+              iptables -D INPUT -s ${ip} -p tcp --dport ${toString ssh.port} -j ACCEPT 2>/dev/null || true
+            '') otherPublicIPs}
+          ''}
 
-      iptables -D INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString security.ssh.port} \
-        -m state --state NEW -m recent --set --name SSH 2>/dev/null || true
-      iptables -D INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString security.ssh.port} \
-        -m state --state NEW -m recent --update \
-        --seconds ${toString security.rateLimiting.timeWindow} \
-        --hitcount ${toString security.rateLimiting.maxAttempts} \
-        --name SSH -j DROP 2>/dev/null || true
-    '';
-  };
+          iptables -D INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString ssh.port} \
+            -m state --state NEW -m recent --set --name SSH 2>/dev/null || true
+          iptables -D INPUT ! -s 10.0.0.0/8 -p tcp --dport ${toString ssh.port} \
+            -m state --state NEW -m recent --update \
+            --seconds ${toString rateLimiting.timeWindow} \
+            --hitcount ${toString rateLimiting.maxAttempts} \
+            --name SSH -j DROP 2>/dev/null || true
+        '';
+      }
+    else
+      {
+        interfaces.wg-admin.allowedTCPPorts = [ ssh.port ];
+      }
+  );
 }

--- a/modules/tailscale/default.nix
+++ b/modules/tailscale/default.nix
@@ -24,6 +24,15 @@
     sopsFile = ./secrets.yaml;
   };
 
-  # Allow Tailscale traffic
-  networking.firewall.trustedInterfaces = [ "tailscale0" ];
+  # Explicit port allowlist for Headscale users (no trustedInterfaces)
+  # - 80, 443: Web services (Nextcloud on tau)
+  # - 3000: Grafana (rho)
+  # - 8010: Buildbot (psi)
+  # SSH and internal services remain wg-admin only
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [
+    80
+    443
+    3000
+    8010
+  ];
 }

--- a/modules/vaultwarden/default.nix
+++ b/modules/vaultwarden/default.nix
@@ -21,6 +21,9 @@
       SSO_PKCE = true;
       SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION = true;
 
+      # Organization
+      ORG_CREATION_USERS = "sjang.bioe@gmail.com";
+
       ROCKET_PORT = 8000;
     };
   };


### PR DESCRIPTION
- **feat(headscale): add organization creation rule**
- **security(sshd): restrict SSH to WireGuard except bastion (eta)**
- **security(headscale): add ACL policy for service-only access**
- **security(tailscale): replace trustedInterfaces with explicit port allowlist**
