### PR TITLE
add ollama on psi

### DIFF
--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -1,7 +1,8 @@
 { config, pkgs, ... }:
 let
+  inherit (config.networking.sbee) hosts;
   domain = "cloud.sjanglab.org";
-  tauWgAdmin = config.networking.sbee.hosts.tau.wg-admin;
+  ollamaDomain = "ollama.sjanglab.org";
 in
 {
   imports = [
@@ -34,7 +35,36 @@ in
           -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
           -avz --chmod=D750,F640 \
           /var/lib/acme/${domain}/ \
-          acme-sync@${tauWgAdmin}:/var/lib/acme/${domain}/
+          acme-sync@${hosts.tau.wg-admin}:/var/lib/acme/${domain}/
+      '';
+    };
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+  };
+
+  # ACME certificate for ollama.sjanglab.org (internal only)
+  security.acme.certs.${ollamaDomain} = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+    group = "acme";
+    postRun = ''
+      ${pkgs.systemd}/bin/systemctl start --no-block acme-sync-ollama-to-psi.service || true
+    '';
+  };
+
+  # Sync ollama.sjanglab.org cert to psi after ACME renewal
+  systemd.services.acme-sync-ollama-to-psi = {
+    description = "Sync ${ollamaDomain} certificate to psi";
+    serviceConfig = {
+      Type = "oneshot";
+      User = "acme";
+      ExecStart = pkgs.writeShellScript "sync-ollama-cert-to-psi" ''
+        ${pkgs.rsync}/bin/rsync \
+          -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
+          -avz --chmod=D750,F640 \
+          /var/lib/acme/${ollamaDomain}/ \
+          acme-sync-ollama@${hosts.psi.wg-admin}:/var/lib/acme/${ollamaDomain}/
       '';
     };
     after = [ "network-online.target" ];

--- a/hosts/psi.nix
+++ b/hosts/psi.nix
@@ -14,6 +14,7 @@
     ../modules/borgbackup/psi/client.nix
     ../modules/monitoring/vector
     ../modules/harmonia
+    ../modules/ollama
     ../modules/icebox/databases.nix
   ];
 

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -21,6 +21,8 @@ in
       dns = {
         base_domain = "sbee.lab";
         magic_dns = true;
+        # Route sjanglab.org queries to MagicDNS (Split DNS)
+        search_domains = [ "sjanglab.org" ];
         nameservers.global = [
           "1.1.1.1"
           "8.8.8.8"
@@ -35,6 +37,11 @@ in
             name = "n8n.sjanglab.org";
             type = "A";
             value = "100.64.0.3"; # tau headscale IP
+          }
+          {
+            name = "ollama.sjanglab.org";
+            type = "A";
+            value = "100.64.0.1"; # psi headscale IP
           }
         ];
       };

--- a/modules/ollama/default.nix
+++ b/modules/ollama/default.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  port = 11434;
+  domain = "ollama.sjanglab.org";
+  certDir = "/var/lib/acme/${domain}";
+
+  # Public key for acme-sync from eta
+  acmeSyncPubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7mZ/UfOMpnrHaIigljsGWXCQAovWezdPpA3WQy1Qgu acme-sync@eta";
+in
+{
+  services.ollama = {
+    enable = true;
+    package = pkgs.ollama-cuda;
+    host = "127.0.0.1"; # Only listen locally, nginx handles external
+    inherit port;
+    models = "/workspace/ollama/models";
+    home = "/workspace/ollama";
+    # Explicit user/group to disable DynamicUser (needed for /workspace access)
+    user = "ollama";
+    group = "ollama";
+    environmentVariables = {
+      CUDA_VISIBLE_DEVICES = "all";
+      OLLAMA_NUM_PARALLEL = "2";
+      OLLAMA_KEEP_ALIVE = "5m";
+      # Allow requests from nginx proxy
+      OLLAMA_ORIGINS = "https://ollama.sjanglab.org,https://*.sjanglab.org";
+    };
+  };
+
+  # Create ollama user/group for /workspace access
+  users.users.ollama = {
+    isSystemUser = true;
+    group = "ollama";
+    home = "/workspace/ollama";
+  };
+  users.groups.ollama = { };
+
+  # Disable DynamicUser to allow /workspace access with static user
+  systemd.services.ollama.serviceConfig.DynamicUser = lib.mkForce false;
+
+  # acme-sync user for receiving certificates from eta
+  users.users.acme-sync-ollama = {
+    isSystemUser = true;
+    group = "acme-sync-ollama";
+    home = certDir;
+    shell = "/run/current-system/sw/bin/bash";
+    openssh.authorizedKeys.keys = [ acmeSyncPubKey ];
+  };
+  users.groups.acme-sync-ollama.members = [ "nginx" ];
+
+  # Reload nginx when certificates are updated
+  systemd.services.acme-sync-ollama-reload-nginx = {
+    description = "Reload nginx after ollama certificate sync";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${config.systemd.package}/bin/systemctl reload nginx";
+    };
+  };
+  systemd.paths.acme-sync-ollama-watch = {
+    wantedBy = [ "multi-user.target" ];
+    pathConfig = {
+      PathChanged = "${certDir}/fullchain.pem";
+      Unit = "acme-sync-ollama-reload-nginx.service";
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+
+    virtualHosts.${domain} = {
+      forceSSL = true;
+      sslCertificate = "${certDir}/fullchain.pem";
+      sslCertificateKey = "${certDir}/key.pem";
+
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString port}";
+        recommendedProxySettings = false; # Override Host header manually
+        extraConfig = ''
+          # Override Host header for ollama
+          proxy_set_header Host 127.0.0.1:${toString port};
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+
+          # Ollama streaming responses
+          proxy_buffering off;
+          proxy_read_timeout 600s;
+          proxy_send_timeout 600s;
+
+          # Large model responses
+          client_max_body_size 100M;
+        '';
+      };
+    };
+  };
+
+  # Firewall: HTTPS for Tailscale only
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 443 ];
+
+  # Ensure directories exist on /workspace (SSD RAID0)
+  systemd.tmpfiles.rules = [
+    "d /workspace/ollama 0755 ollama ollama -"
+    "d /workspace/ollama/models 0755 ollama ollama -"
+    "d ${certDir} 0750 acme-sync-ollama acme-sync-ollama - -"
+  ];
+}


### PR DESCRIPTION
psi:
- Add ollama module with CUDA GPU support
- nginx reverse proxy for ollama.sjanglab.org
- acme-sync user to receive certs from eta
- Explicit ollama user/group (DynamicUser disabled for /workspace)
- Models stored on /workspace SSD for fast loading

eta:
- ACME cert for ollama.sjanglab.org (Cloudflare DNS challenge)
- rsync sync service to psi after cert renewal

headscale:
- Add ollama.sjanglab.org → 100.64.0.1 (psi) DNS record
- Add sjanglab.org to search_domains for Split DNS

Access: Tailscale network only via https://ollama.sjanglab.org
