### PR TITLE
refactor certification sync logic into module

### DIFF
--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -1,9 +1,6 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 let
   inherit (config.networking.sbee) hosts;
-  domain = "cloud.sjanglab.org";
-  ollamaDomain = "ollama.sjanglab.org";
-  doclingDomain = "docling.sjanglab.org";
 in
 {
   imports = [
@@ -17,88 +14,36 @@ in
     ../modules/monitoring/vector
     ../modules/monitoring/reverse-proxy.nix
     ../modules/n8n/reverse-proxy.nix
+    ../modules/acme/sync.nix
+  ];
+
+  acmeSyncer.mkSender = [
+    {
+      domain = "cloud.sjanglab.org";
+      serviceName = "acme-sync-to-tau";
+      remoteHost = hosts.tau.wg-admin;
+    }
+    {
+      domain = "ollama.sjanglab.org";
+      serviceName = "acme-sync-ollama-to-psi";
+      remoteUser = "acme-sync-ollama";
+      remoteHost = hosts.psi.wg-admin;
+    }
+    {
+      domain = "docling.sjanglab.org";
+      serviceName = "acme-sync-docling-to-psi";
+      remoteHost = hosts.psi.wg-admin;
+    }
   ];
 
   disko.rootDisk = "/dev/vda";
 
-  # Sync cloud.sjanglab.org cert to tau after ACME renewal
-  security.acme.certs.${domain}.postRun = ''
-    ${pkgs.systemd}/bin/systemctl start --no-block acme-sync-to-tau.service || true
-  '';
-
-  systemd.services.acme-sync-to-tau = {
-    description = "Sync ${domain} certificate to tau";
-    serviceConfig = {
-      Type = "oneshot";
-      User = "acme";
-      ExecStart = pkgs.writeShellScript "sync-cert-to-tau" ''
-        ${pkgs.rsync}/bin/rsync \
-          -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
-          -avz --chmod=D750,F640 \
-          /var/lib/acme/${domain}/ \
-          acme-sync@${hosts.tau.wg-admin}:/var/lib/acme/${domain}/
-      '';
-    };
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
-  };
-
   # ACME certificate for ollama.sjanglab.org (internal only)
-  security.acme.certs.${ollamaDomain} = {
+  security.acme.certs."ollama.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
     group = "acme";
-    postRun = ''
-      ${pkgs.systemd}/bin/systemctl start --no-block acme-sync-ollama-to-psi.service || true
-    '';
-  };
-
-  # Sync ollama.sjanglab.org cert to psi after ACME renewal
-  systemd.services.acme-sync-ollama-to-psi = {
-    description = "Sync ${ollamaDomain} certificate to psi";
-    serviceConfig = {
-      Type = "oneshot";
-      User = "acme";
-      ExecStart = pkgs.writeShellScript "sync-ollama-cert-to-psi" ''
-        ${pkgs.rsync}/bin/rsync \
-          -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
-          -avz --chmod=D750,F640 \
-          /var/lib/acme/${ollamaDomain}/ \
-          acme-sync-ollama@${hosts.psi.wg-admin}:/var/lib/acme/${ollamaDomain}/
-      '';
-    };
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
-  };
-
-  # Sync docling cert to psi after ACME renewal
-  security.acme.certs.${doclingDomain}.postRun = ''
-    ${pkgs.systemd}/bin/systemctl start --no-block acme-sync-docling-to-psi.service || true
-  '';
-
-  # Sync docling.sjanglab.org cert to psi after ACME renewal
-  systemd.services.acme-sync-docling-to-psi = {
-    description = "Sync ${doclingDomain} certificate to psi";
-    serviceConfig = {
-      Type = "oneshot";
-      User = "acme";
-      ExecStart = pkgs.writeShellScript "sync-docling-cert-to-psi" ''
-        ${pkgs.rsync}/bin/rsync \
-          -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
-          -avz --chmod=D750,F640 \
-          /var/lib/acme/${doclingDomain}/ \
-          acme-sync@${hosts.psi.wg-admin}:/var/lib/acme/${doclingDomain}/
-      '';
-    };
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
-  };
-
-  sops.secrets.acme-sync-ssh-key = {
-    sopsFile = ../modules/acme/secrets.yaml;
-    owner = "acme";
-    mode = "0400";
   };
 
   networking.hostName = "eta";

--- a/modules/acme/sync.nix
+++ b/modules/acme/sync.nix
@@ -1,0 +1,164 @@
+# ACME certificate rsync sync module
+#
+# Usage:
+#   imports = [ ../acme/sync.nix ];
+#   acmeSyncer.mkSender = [ { domain = "example.com"; serviceName = "acme-sync-to-host"; remoteHost = "10.0.0.1"; } ];
+#   acmeSyncer.mkReceiver = [ { domain = "example.com"; } ];
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.acmeSyncer;
+
+  acmeSyncPubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7mZ/UfOMpnrHaIigljsGWXCQAovWezdPpA3WQy1Qgu acme-sync@eta";
+in
+{
+  options.acmeSyncer = {
+    mkSender = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            domain = lib.mkOption { type = lib.types.str; };
+            serviceName = lib.mkOption { type = lib.types.str; };
+            remoteUser = lib.mkOption {
+              type = lib.types.str;
+              default = "acme-sync";
+            };
+            remoteHost = lib.mkOption { type = lib.types.str; };
+          };
+        }
+      );
+      default = [ ];
+    };
+
+    mkReceiver = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            domain = lib.mkOption { type = lib.types.str; };
+            user = lib.mkOption {
+              type = lib.types.str;
+              default = "acme-sync";
+            };
+            reloadService = lib.mkOption {
+              type = lib.types.str;
+              default = "nginx";
+            };
+            extraGroupMembers = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ "nginx" ];
+            };
+          };
+        }
+      );
+      default = [ ];
+    };
+  };
+
+  # Fixed-size list for lib.mkMerge to avoid infinite recursion.
+  # Dynamic content lives inside attrset VALUES (lazy), not in the list structure.
+  config = lib.mkMerge [
+    # --- Senders ---
+    {
+      security.acme.certs = builtins.listToAttrs (
+        map (
+          s:
+          lib.nameValuePair s.domain {
+            postRun = ''
+              ${pkgs.systemd}/bin/systemctl start --no-block ${s.serviceName}.service || true
+            '';
+          }
+        ) cfg.mkSender
+      );
+
+      systemd.services = builtins.listToAttrs (
+        map (
+          s:
+          lib.nameValuePair s.serviceName {
+            description = "Sync ${s.domain} certificate to ${s.remoteHost}";
+            serviceConfig = {
+              Type = "oneshot";
+              User = "acme";
+              ExecStart = pkgs.writeShellScript "sync-${s.serviceName}" ''
+                ${pkgs.rsync}/bin/rsync \
+                  -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
+                  -avz --chmod=D750,F640 \
+                  /var/lib/acme/${s.domain}/ \
+                  ${s.remoteUser}@${s.remoteHost}:/var/lib/acme/${s.domain}/
+              '';
+            };
+            after = [ "network-online.target" ];
+            wants = [ "network-online.target" ];
+          }
+        ) cfg.mkSender
+      );
+    }
+
+    # Shared SSH key (only when senders exist)
+    (lib.mkIf (cfg.mkSender != [ ]) {
+      sops.secrets.acme-sync-ssh-key = {
+        sopsFile = ./secrets.yaml;
+        owner = "acme";
+        mode = "0400";
+      };
+    })
+
+    # --- Receivers ---
+    {
+      users.users = builtins.listToAttrs (
+        map (
+          r:
+          lib.nameValuePair r.user {
+            isSystemUser = true;
+            group = r.user;
+            home = "/var/lib/acme/${r.domain}";
+            shell = pkgs.bashInteractive;
+            openssh.authorizedKeys.keys = [ acmeSyncPubKey ];
+          }
+        ) cfg.mkReceiver
+      );
+
+      users.groups = builtins.listToAttrs (
+        map (
+          r:
+          lib.nameValuePair r.user {
+            members = r.extraGroupMembers;
+          }
+        ) cfg.mkReceiver
+      );
+
+      systemd.tmpfiles.rules = lib.concatMap (r: [
+        "d /var/lib/acme/${r.domain} 0750 ${r.user} ${r.user} - -"
+      ]) cfg.mkReceiver;
+
+      systemd.services = builtins.listToAttrs (
+        map (
+          r:
+          lib.nameValuePair "${r.user}-reload-${r.reloadService}" {
+            description = "Reload ${r.reloadService} after certificate sync for ${r.domain}";
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "${pkgs.systemd}/bin/systemctl reload ${r.reloadService}";
+            };
+          }
+        ) cfg.mkReceiver
+      );
+
+      systemd.paths = builtins.listToAttrs (
+        map (
+          r:
+          lib.nameValuePair "${r.user}-watch" {
+            wantedBy = [ "multi-user.target" ];
+            pathConfig = {
+              PathChanged = "/var/lib/acme/${r.domain}/fullchain.pem";
+              Unit = "${r.user}-reload-${r.reloadService}.service";
+            };
+          }
+        ) cfg.mkReceiver
+      );
+    }
+  ];
+}

--- a/modules/n8n/reverse-proxy.nix
+++ b/modules/n8n/reverse-proxy.nix
@@ -3,13 +3,25 @@
 # Security: Only webhook endpoints are exposed to the internet.
 # UI/API access is blocked (403) - use Tailscale for full access.
 # Webhooks use their own authentication (URL tokens, header verification).
-{ config, pkgs, ... }:
+{ config, ... }:
 let
   inherit (config.networking.sbee) hosts;
   n8nDomain = "n8n.sjanglab.org";
 in
 {
-  imports = [ ../acme ];
+  imports = [
+    ../acme
+    ../acme/sync.nix
+  ];
+
+  acmeSyncer.mkSender = [
+    {
+      domain = n8nDomain;
+      serviceName = "acme-sync-n8n-to-tau";
+      remoteUser = "acme-sync-n8n";
+      remoteHost = hosts.tau.wg-admin;
+    }
+  ];
 
   # ACME certificate (DNS challenge via Cloudflare)
   # Also synced to tau for split DNS access
@@ -18,33 +30,6 @@ in
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
     group = "nginx";
-    postRun = ''
-      ${pkgs.systemd}/bin/systemctl start --no-block acme-sync-n8n-to-tau.service || true
-    '';
-  };
-
-  # Sync n8n cert to tau after ACME renewal
-  systemd.services.acme-sync-n8n-to-tau = {
-    description = "Sync ${n8nDomain} certificate to tau";
-    serviceConfig = {
-      Type = "oneshot";
-      User = "acme";
-      ExecStart = pkgs.writeShellScript "sync-n8n-cert-to-tau" ''
-        ${pkgs.rsync}/bin/rsync \
-          -e "${pkgs.openssh}/bin/ssh -i ${config.sops.secrets.acme-sync-ssh-key.path} -p 10022 -o StrictHostKeyChecking=accept-new" \
-          -avz --chmod=D750,F640 \
-          /var/lib/acme/${n8nDomain}/ \
-          acme-sync-n8n@${hosts.tau.wg-admin}:/var/lib/acme/${n8nDomain}/
-      '';
-    };
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
-  };
-
-  sops.secrets.acme-sync-ssh-key = {
-    sopsFile = ../acme/secrets.yaml;
-    owner = "acme";
-    mode = "0400";
   };
 
   services.nginx.virtualHosts.${n8nDomain} = {


### PR DESCRIPTION
Replace per-host rsync boilerplate (4 senders + 4 receivers) with a
declarative NixOS module. Hosts now import modules/acme/sync.nix and
set acmeSyncer.mkSender/mkReceiver lists. This eliminates ~80 lines
of duplicated user/service/path/tmpfiles definitions while keeping
all systemd unit names identical (no migration needed).
