### PR TITLE
add gatus monotoring dashboard and remove antipattern

### DIFF
--- a/.sops.nix
+++ b/.sops.nix
@@ -41,6 +41,12 @@ let
       "modules/attic/secrets.yaml" = [ "eta" ];
       "modules/authentik/secrets.yaml" = [ "eta" ];
       "modules/headscale/secrets.yaml" = [ "eta" ];
+      "modules/gatus/secrets.yaml" = [
+        "eta"
+        "psi"
+        "rho"
+        "tau"
+      ];
       "modules/vaultwarden/secrets.yaml" = [ "eta" ];
       "modules/tailscale/secrets.yaml" = [
         "psi"

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -57,6 +57,14 @@ creation_rules:
     path_regex: modules/buildbot/secrets.yaml
   - key_groups:
       - age:
+          - age1zdhqm6ptcnuu3tf2lzcngqmf6eud7jfah7v8falfy5mdksmnfuzq35sq54
+          - age18yuzugm0f2l7cc4sdmp5f442af2w897x9l9syeaef3yx3jzc5pjs9zez0f
+          - age1u2ymsehnq872lzj086yf87f6k0zq52x66qz84kp3s6crtcxsts3s9fsneq
+          - age13v0djuhkmnd06zvct0zc6sddykqpk3j9k8ev5sfgd6gtj82s0avs68psvj
+          - age1axh7747a46nm8x6l42nalaptf6xh7q9t9z8qlwrwqg4xc89leqjsaaeu6r
+    path_regex: modules/gatus/secrets.yaml
+  - key_groups:
+      - age:
           - age18yuzugm0f2l7cc4sdmp5f442af2w897x9l9syeaef3yx3jzc5pjs9zez0f
           - age1axh7747a46nm8x6l42nalaptf6xh7q9t9z8qlwrwqg4xc89leqjsaaeu6r
     path_regex: modules/harmonia/secrets.yaml

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -10,6 +10,7 @@ in
     ../modules/headscale
     ../modules/authentik
     ../modules/vaultwarden
+    ../modules/gatus
     ../modules/buildbot/reverse-proxy.nix
     ../modules/monitoring/vector
     ../modules/monitoring/reverse-proxy.nix

--- a/modules/authentik/default.nix
+++ b/modules/authentik/default.nix
@@ -1,6 +1,17 @@
 { config, ... }:
 {
-  imports = [ ../acme ];
+  imports = [
+    ../acme
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "Authentik";
+      url = "https://auth.sjanglab.org";
+      group = "auth";
+    }
+  ];
 
   services.authentik = {
     enable = true;

--- a/modules/authentik/default.nix
+++ b/modules/authentik/default.nix
@@ -34,12 +34,13 @@
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
+    group = "nginx";
   };
 
   # Nginx reverse proxy
   services.nginx.virtualHosts."auth.sjanglab.org" = {
     forceSSL = true;
-    enableACME = true;
+    useACMEHost = "auth.sjanglab.org";
 
     locations."/" = {
       proxyPass = "http://127.0.0.1:9000";

--- a/modules/authentik/nginx-locations.nix
+++ b/modules/authentik/nginx-locations.nix
@@ -1,0 +1,61 @@
+# Shared Authentik forward auth nginx locations
+#
+# Usage:
+#   let
+#     authentikAuth = import ../authentik/nginx-locations.nix { inherit (config.networking.sbee) hosts; };
+#   in
+#   {
+#     services.nginx.virtualHosts.${domain}.locations = authentikAuth.locations // {
+#       "/" = {
+#         proxyPass = "http://127.0.0.1:${port}";
+#         extraConfig = authentikAuth.protectLocation + ''
+#           client_max_body_size 100M;
+#         '';
+#       };
+#     };
+#   }
+{ hosts }:
+let
+  authentikOutpost = "http://${hosts.eta.wg-admin}:9000";
+in
+{
+  # Add these locations to an nginx virtualHost for Authentik forward auth
+  locations = {
+    # Auth endpoint (internal, for auth_request subrequest)
+    "/outpost.goauthentik.io/auth/nginx" = {
+      proxyPass = "${authentikOutpost}/outpost.goauthentik.io/auth/nginx";
+      extraConfig = ''
+        internal;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header Authorization $http_authorization;
+      '';
+    };
+
+    # Start/callback (external, for browser redirects)
+    "/outpost.goauthentik.io" = {
+      proxyPass = "${authentikOutpost}/outpost.goauthentik.io";
+      extraConfig = ''
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header Authorization $http_authorization;
+      '';
+    };
+
+    # Signin redirect (same domain, not auth.sjanglab.org)
+    "@authentik_signin" = {
+      extraConfig = ''
+        internal;
+        return 302 /outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
+      '';
+    };
+  };
+
+  # Add this to extraConfig of locations protected by Authentik
+  protectLocation = ''
+    auth_request /outpost.goauthentik.io/auth/nginx;
+    auth_request_set $authentik_email $upstream_http_x_authentik_email;
+    error_page 401 = @authentik_signin;
+    proxy_set_header X-authentik-email $authentik_email;
+  '';
+}

--- a/modules/buildbot/reverse-proxy.nix
+++ b/modules/buildbot/reverse-proxy.nix
@@ -1,4 +1,5 @@
 # Buildbot reverse proxy (deployed on eta)
+# No nginx auth: Buildbot uses its own Authentik OIDC integration for login
 { config, ... }:
 let
   inherit (config.networking.sbee) hosts;

--- a/modules/buildbot/reverse-proxy.nix
+++ b/modules/buildbot/reverse-proxy.nix
@@ -5,7 +5,18 @@ let
   buildbotDomain = "buildbot.sjanglab.org";
 in
 {
-  imports = [ ../acme ];
+  imports = [
+    ../acme
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "Buildbot";
+      url = "https://buildbot.sjanglab.org";
+      group = "ci";
+    }
+  ];
 
   services.nginx.virtualHosts.${buildbotDomain} = {
     forceSSL = true;

--- a/modules/docling/default.nix
+++ b/modules/docling/default.nix
@@ -7,7 +7,18 @@ let
   authentikOutpost = "http://${hosts.eta.wg-admin}:9000";
 in
 {
-  imports = [ ../acme/sync.nix ];
+  imports = [
+    ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "Docling";
+      group = "ai";
+      url = "http://127.0.0.1:${toString doclingPort}/health";
+    }
+  ];
 
   acmeSyncer.mkReceiver = [
     { inherit domain; }

--- a/modules/gatus/check.nix
+++ b/modules/gatus/check.nix
@@ -1,0 +1,164 @@
+# Gatus health check registration module
+#
+# Pull (Gatus server polls the URL directly from eta):
+#   gatusCheck.pull = [
+#     { name = "Authentik"; url = "https://auth.sjanglab.org"; group = "auth"; }
+#   ];
+#
+# Push (host checks localhost, pushes result to Gatus external endpoint API):
+#   gatusCheck.push = [
+#     { name = "Ollama"; group = "ai"; url = "http://127.0.0.1:11434"; }
+#     { name = "borgbackup"; group = "backup"; systemdService = "borgbackup-job-main.service"; }
+#   ];
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.gatusCheck;
+  gatusApi = "https://gatus.sjanglab.org";
+
+  # Gatus external endpoint key: "${group}_${name}" with spaces/special chars → hyphens
+  mkKey =
+    ep:
+    let
+      sanitize = s: builtins.replaceStrings [ " " "/" "_" "," "." ] [ "-" "-" "-" "-" "-" ] s;
+    in
+    "${sanitize ep.group}_${sanitize ep.name}";
+
+  mkPushScript =
+    ep:
+    pkgs.writeShellScript "gatus-push-${mkKey ep}" (
+      if ep.systemdService != null then
+        ''
+          if ${pkgs.systemd}/bin/systemctl is-active --quiet ${ep.systemdService}; then
+            success=true
+            error=""
+          else
+            success=false
+            error="$(${pkgs.systemd}/bin/systemctl show -p SubState --value ${ep.systemdService})"
+          fi
+          ${pkgs.curl}/bin/curl -sf --max-time 10 \
+            -X POST \
+            -H "Authorization: Bearer $GATUS_EXTERNAL_TOKEN" \
+            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external?success=$success&error=$error"
+        ''
+      else
+        ''
+          status=$(${pkgs.curl}/bin/curl -sf --max-time 30 -o /dev/null -w "%{http_code}" "${ep.url}" 2>/dev/null) || true
+          if [ "$status" = "${toString ep.expectedStatus}" ]; then
+            success=true
+            error=""
+          else
+            success=false
+            error="expected ${toString ep.expectedStatus}, got $status"
+          fi
+          ${pkgs.curl}/bin/curl -sf --max-time 10 \
+            -X POST \
+            -H "Authorization: Bearer $GATUS_EXTERNAL_TOKEN" \
+            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external?success=$success&error=$error"
+        ''
+    );
+
+  pullSubmodule = lib.types.submodule {
+    options = {
+      name = lib.mkOption { type = lib.types.str; };
+      url = lib.mkOption { type = lib.types.str; };
+      group = lib.mkOption { type = lib.types.str; };
+      interval = lib.mkOption {
+        type = lib.types.str;
+        default = "5m";
+      };
+      conditions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "[STATUS] == 200"
+          "[CERTIFICATE_EXPIRATION] > 720h"
+        ];
+      };
+    };
+  };
+
+  pushSubmodule = lib.types.submodule {
+    options = {
+      name = lib.mkOption { type = lib.types.str; };
+      group = lib.mkOption { type = lib.types.str; };
+      url = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      expectedStatus = lib.mkOption {
+        type = lib.types.int;
+        default = 200;
+      };
+      systemdService = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      interval = lib.mkOption {
+        type = lib.types.int;
+        default = 300;
+        description = "Check interval in seconds";
+      };
+    };
+  };
+in
+{
+  options.gatusCheck = {
+    pull = lib.mkOption {
+      type = lib.types.listOf pullSubmodule;
+      default = [ ];
+      description = "Endpoints that Gatus polls directly (must be reachable from eta)";
+    };
+    push = lib.mkOption {
+      type = lib.types.listOf pushSubmodule;
+      default = [ ];
+      description = "Endpoints checked locally and pushed to Gatus external endpoint API";
+    };
+  };
+
+  # Push: systemd timers on the declaring host
+  config = lib.mkIf (cfg.push != [ ]) {
+    # Resolve gatus.sjanglab.org → eta WG IP for hosts behind NAT/WG
+    networking.hosts.${config.networking.sbee.hosts.eta.wg-admin} = [ "gatus.sjanglab.org" ];
+
+    sops.secrets.gatus-push-token = {
+      sopsFile = ./secrets.yaml;
+    };
+
+    systemd.services = builtins.listToAttrs (
+      map (
+        ep:
+        lib.nameValuePair "gatus-push-${mkKey ep}" {
+          description = "Push health check: ${ep.name}";
+          serviceConfig = {
+            Type = "oneshot";
+            EnvironmentFile = config.sops.secrets.gatus-push-token.path;
+            ExecStart = mkPushScript ep;
+          };
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+        }
+      ) cfg.push
+    );
+
+    systemd.timers = builtins.listToAttrs (
+      map (
+        ep:
+        lib.nameValuePair "gatus-push-${mkKey ep}" {
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnBootSec = "1min";
+            OnUnitActiveSec = "${toString ep.interval}s";
+            RandomizedDelaySec = "30s";
+          };
+        }
+      ) cfg.push
+    );
+  };
+
+  # Pull: consumed by gatus/default.nix via config.gatusCheck.pull
+  # (no config generated here — the Gatus server reads it)
+}

--- a/modules/gatus/default.nix
+++ b/modules/gatus/default.nix
@@ -84,12 +84,13 @@ in
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
+    group = "nginx";
   };
 
   # Nginx reverse proxy
   services.nginx.virtualHosts.${domain} = {
     forceSSL = true;
-    enableACME = true;
+    useACMEHost = domain;
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString port}";
       proxyWebsockets = true;

--- a/modules/gatus/default.nix
+++ b/modules/gatus/default.nix
@@ -1,0 +1,126 @@
+{ config, lib, ... }:
+let
+  inherit (config.networking.sbee) hosts;
+  domain = "gatus.sjanglab.org";
+  port = 8081;
+  systemCollector = hosts.rho.wg-admin;
+  cfg = config.gatusCheck;
+in
+{
+  imports = [
+    ../acme
+    ./check.nix
+  ];
+
+  services.gatus = {
+    enable = true;
+    environmentFile = config.sops.secrets.gatus-env.path;
+    settings = {
+      web.port = port;
+      metrics = true;
+
+      security.basic = {
+        username = "admin";
+        # bcrypt hash → base64 encoded, interpolated from environmentFile
+        password-bcrypt-base64 = "\${GATUS_SECURITY_BASIC_PASSWORD}";
+      };
+
+      alerting.ntfy = {
+        topic = "gatus";
+        url = "https://ntfy.sjanglab.org";
+        priority = 3;
+        default-alert = {
+          failure-threshold = 3;
+          success-threshold = 2;
+          send-on-resolved = true;
+        };
+      };
+
+      # Consumed from gatusCheck.pull declared by service modules
+      endpoints = map (ep: {
+        inherit (ep)
+          name
+          url
+          group
+          interval
+          conditions
+          ;
+        alerts = [ { type = "ntfy"; } ];
+      }) cfg.pull;
+
+      # External endpoints: each remote host pushes its own health status
+      # Cannot be auto-collected from gatusCheck.push (cross-host boundary)
+      # Token interpolated from environmentFile at runtime
+      external-endpoints =
+        let
+          mkExtEndpoint = name: group: {
+            inherit name group;
+            token = "\${GATUS_EXTERNAL_TOKEN}";
+            alerts = [ { type = "ntfy"; } ];
+          };
+        in
+        [
+          # psi
+          (mkExtEndpoint "Ollama" "ai")
+          (mkExtEndpoint "Docling" "ai")
+          # tau
+          (mkExtEndpoint "Nextcloud" "apps")
+          (mkExtEndpoint "n8n" "apps")
+          # rho
+          (mkExtEndpoint "Grafana" "monitoring")
+          (mkExtEndpoint "Prometheus" "monitoring")
+          (mkExtEndpoint "Loki" "monitoring")
+          (mkExtEndpoint "PostgreSQL" "db")
+        ];
+    };
+  };
+
+  sops.secrets.gatus-env = {
+    sopsFile = ./secrets.yaml;
+  };
+
+  # ACME certificate (DNS challenge via Cloudflare)
+  security.acme.certs.${domain} = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+  };
+
+  # Nginx reverse proxy
+  services.nginx.virtualHosts.${domain} = {
+    forceSSL = true;
+    enableACME = true;
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:${toString port}";
+      proxyWebsockets = true;
+      extraConfig = ''
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+      '';
+    };
+  };
+
+  # Vector: scrape Gatus /metrics → push to rho Prometheus
+  # Independent source+sink pair, does not interfere with existing Vector pipeline
+  services.vector.settings = {
+    sources.gatus_metrics = {
+      type = "prometheus_scrape";
+      endpoints = [ "http://127.0.0.1:${toString port}/metrics" ];
+      scrape_interval_secs = 60;
+    };
+    sinks.gatus_metrics_remote = lib.mkIf (config.networking.hostName != "rho") {
+      type = "prometheus_remote_write";
+      inputs = [ "gatus_metrics" ];
+      endpoint = "http://${systemCollector}:9090/api/v1/write";
+      batch.timeout_secs = 10;
+      healthcheck.enabled = false;
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/modules/gatus/default.nix
+++ b/modules/gatus/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (config.networking.sbee) hosts;
   domain = "gatus.sjanglab.org";
-  port = 8081;
+  port = 8081; # 8080 is used by headscale
   systemCollector = hosts.rho.wg-admin;
   cfg = config.gatusCheck;
 in

--- a/modules/gatus/secrets.yaml
+++ b/modules/gatus/secrets.yaml
@@ -1,0 +1,54 @@
+gatus-env: ENC[AES256_GCM,data:R4uQGpFku9tZigWTQ//6M4e5jx07LPPWM/TQN0k9y+EE7DQE0zRnUNWRMVCgjP/8WvvBcIXReUKG0mPZofLxKN+zafvz6xwp/tqv27JfXDj/l5B12h5znhCicVyT65cwlN6smW5pk2dt8sOrvyA5Htq5DS096FI3Ra7cZx6NN67HNJZtYtiUCDb3w1qHYQCfY7GqqnnNMsb80xNjuD12Jq1yPB+D8uW5aZzg27uSfiMnnC3c,iv:Ek5ogFI3nWNAOHrcAfTMHQJJFissBqivBcvD+eiAOcI=,tag:Ept87sO6gC71oUPIzNTf3A==,type:str]
+gatus_pass: ENC[AES256_GCM,data:7Mw1qo40gdEEOvh0F23sALFcGuGH1vukC2NEok7VCKY2jwNMoWSV65g3ieZQeviw55l0ZxTpBf2WCqxxShU=,iv:PHz2OizP2UcHtyyL4eOsAvH64ML8CervBW0JZpS+CI4=,tag:cqd4kaNq0VzuYeeRQumVtQ==,type:str]
+gatus-push-token: ENC[AES256_GCM,data:PdPm0ptZUKDdyZ5Fn64LkH9/uEUuqQhkxRwq02QmHno1208jlHzGnuCkrpar1piaICko6yD/lPUMNgNnC+s68Q==,iv:ZT8740WVPrJHHrvbaw0UnkXl8UvUbHK9HSqlEdihHPU=,tag:rTIkygotiMAkAfukWkBG5A==,type:str]
+sops:
+  age:
+    - recipient: age1zdhqm6ptcnuu3tf2lzcngqmf6eud7jfah7v8falfy5mdksmnfuzq35sq54
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzYTI5MG1VZHVrUTFUNm95
+        N2pTY0lJZHFLRFRuY3ZORnQyM3pqNEdYbkNrCjh0dEwxbG5XWTlMNW53MzdObnF0
+        SDFmcmZpQlJsbmtKdXBQeTdOZTN5Y1EKLS0tIFI0Z0t4WlhXa2NCVFlsUFAzSjJ0
+        dVN1QjR1bVZaaVJDMVJ2V0llVUxtM0kKZf2FwifoJ54i7hGS6NqYwTsEMLzvBv7n
+        mZUF8zXxEzuXVORuRLkaad2+XYWLZljgL3wUmBu8P86377oZeU4CIQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age18yuzugm0f2l7cc4sdmp5f442af2w897x9l9syeaef3yx3jzc5pjs9zez0f
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDWVNkWGhPZGhOY1MxWVJL
+        RWhRRTlUNDBtbDZBOG9OU1A3U2pybWpHWWpVCmI1b0VORWk3QTFHNW8rbFMxazZH
+        TythaVdieEZrZ0laOENFNWlaazBPZU0KLS0tIGRKTkoxQ1U4MnFucjY1Wnc1cnJt
+        MW1KVVZBWmRKOTVLZlNQWk1JOGs1Sk0Kx1/8cq+RIeD/MUgygAaMt/vqf6psPyAh
+        LxEmw90d+dg7seEg9sxOR/CB6iNApHFae1/WSq+1Yi7x6+kSHcNwnw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1u2ymsehnq872lzj086yf87f6k0zq52x66qz84kp3s6crtcxsts3s9fsneq
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSSXRQMTNtYkhWRTBTSWNw
+        dFp2MnkrMmJua0JCbXluMFg5OWNBemxBVUI4CjVvc05YbkxjQjdwUTd0U2tWa3NN
+        T1lLakJZajdRRWJoMk1sVmFqc2EwQlkKLS0tIGZzQWVnaUNLcUtqd0VhTWFuTXht
+        UGxpU0c2S20ycTVzbFhvbGJNOGN4a3MKXzKiOle+DHghYLBX9YaTXQaPmMfem1z7
+        Atrtmug8EP8uks5NcDJmiB3WzlB1n47r4scqs7KeMN/Rpsx1XSEIbw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age13v0djuhkmnd06zvct0zc6sddykqpk3j9k8ev5sfgd6gtj82s0avs68psvj
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZ2NsR2VCRmlINGR5Ly90
+        OVREc1A2T1hNQ3UxcU9LQVBmM1ZiVVBTOUdnClNaNnBTMGE4VFQ4UUdqeFRNaFZR
+        d3duNHQ4NVV3NjFQTGZCL3dobmtJdzQKLS0tIFh2MHNtQkNMTVZZSGFNdU9mV3FJ
+        aVRrTjRvV2FxRXhTNnVzbWhCZFp1ZXMKoj2GCZaStrpZ76blIA5lgyuItI0J/9pb
+        oSTYwXM3WDJCh+seHQX1cJsVQNlRoUbxqN/njCDVM29gvBIOP4cjuA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1axh7747a46nm8x6l42nalaptf6xh7q9t9z8qlwrwqg4xc89leqjsaaeu6r
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQ2xES2NEY0Evd3dLMUdV
+        NkVXak9wUy8xbll5OWFvZk1kQlJicTV4dGpZCjVUTEwvK1pqNUpnenAxajhPaTJJ
+        R2oyRGw1UGRWYlp5MTZmb1RzZHpqWlEKLS0tIE1LNHM3RXNFNDEwREhVbENVZHZF
+        a294MkkzUkxWRzlXdUpQRXI5MWpYc2cKAJG7e6mvjeBrSvLGuG5fS0SLVFngaKtA
+        +5V6lj9zXjP5bgkAbYj9ZSmvTlqDFY3pnsycpxbuCc4EtwmqSe420Q==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-03T10:17:42Z"
+  mac: ENC[AES256_GCM,data:LS1pLW4swdHXvCoM2eacNFqplL4ryAC2W7YdcM1o64/XQBHKWm9Mlvh8D3dMbhCYnBU9bmhLFH191GfltvJMm1K6YpahWVgtKhU4trhNkaRarrr0/03WpOgAbDIVMPiCAgPu174679ebe2boHXhTLO6QBQ3vvqhYouJ8PjuQ4Ko=,iv:TzeY8zAPtQ9FlocxWV9doQ7h5uQLEh7VygaFHYBgdBA=,tag:eGUbj01iiyMVSlPCstT8vg==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.11.0

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -3,7 +3,18 @@ let
   policyFile = pkgs.writeText "headscale-policy.json" (builtins.toJSON (import ./policy.nix));
 in
 {
-  imports = [ ../acme ];
+  imports = [
+    ../acme
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "Headscale";
+      url = "https://hs.sjanglab.org/health";
+      group = "auth";
+    }
+  ];
 
   services.headscale = {
     enable = true;

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -103,12 +103,13 @@ in
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
+    group = "nginx";
   };
 
   # Nginx reverse proxy
   services.nginx.virtualHosts."hs.sjanglab.org" = {
     forceSSL = true;
-    enableACME = true;
+    useACMEHost = "hs.sjanglab.org";
 
     locations."/" = {
       proxyPass = "http://127.0.0.1:8080";

--- a/modules/hosts.nix
+++ b/modules/hosts.nix
@@ -5,40 +5,33 @@
   ...
 }:
 let
-  hostOptions = with lib; {
-    ipv4 = mkOption {
-      type = types.str;
-      description = ''
-        own ipv4 address
-      '';
+  hostOptions = {
+    ipv4 = lib.mkOption {
+      type = lib.types.str;
+      description = "Public or private IPv4 address";
     };
 
-    mac = mkOption {
-      type = types.nullOr types.str;
+    mac = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
-      description = ''
-        MAC address of the NIC port used as a gateway
-      '';
+      description = "MAC address of the NIC port used as a gateway";
     };
 
-    wg-admin = mkOption {
-      type = types.nullOr types.str;
+    wg-admin = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
-      description = ''
-        WireGuard interface for admin access (unified)
-      '';
+      description = "WireGuard interface for admin access (unified)";
     };
 
-    gateway = mkOption {
-      type = types.nullOr types.str;
+    gateway = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
-      description = ''
-        Default gateway for this host
-      '';
+      description = "Default gateway for this host";
     };
-    tags = mkOption {
-      type = types.listOf (
-        types.enum [
+
+    tags = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.enum [
           "public-ip"
           "nat-behind"
           "lab-network"
@@ -59,18 +52,18 @@ let
   };
 in
 {
-  options = with lib; {
-    networking.sbee.hosts = mkOption {
-      type = with types; attrsOf (submodule [ { options = hostOptions; } ]);
+  options = {
+    networking.sbee.hosts = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule [ { options = hostOptions; } ]);
       description = "A host in our cluster";
     };
-    networking.sbee.currentHost = mkOption {
-      type = with types; submodule [ { options = hostOptions; } ];
+    networking.sbee.currentHost = lib.mkOption {
+      type = lib.types.submodule [ { options = hostOptions; } ];
       default = config.networking.sbee.hosts.${config.networking.hostName};
       description = "The host that is described by this configuration";
     };
-    networking.sbee.others = mkOption {
-      type = with types; attrsOf (submodule [ { options = hostOptions; } ]);
+    networking.sbee.others = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule [ { options = hostOptions; } ]);
       default = lib.filterAttrs (
         name: _: name != config.networking.hostName
       ) config.networking.sbee.hosts;

--- a/modules/monitoring/grafana.nix
+++ b/modules/monitoring/grafana.nix
@@ -44,6 +44,8 @@ in
         default_theme = "system";
       };
 
+      # Anonymous read-only access: intentional for wg-admin peers.
+      # Grafana only listens on wg-admin, so only WG-authenticated hosts can reach it.
       "auth.anonymous" = {
         enabled = true;
         org_name = "Public";

--- a/modules/monitoring/grafana.nix
+++ b/modules/monitoring/grafana.nix
@@ -10,6 +10,16 @@ let
   prometheusUrl = "http://${wgAdminAddr}:9090";
 in
 {
+  imports = [ ../gatus/check.nix ];
+
+  gatusCheck.push = [
+    {
+      name = "Grafana";
+      group = "monitoring";
+      url = "http://127.0.0.1:3000/api/health";
+    }
+  ];
+
   services.grafana = {
     enable = true;
 

--- a/modules/monitoring/loki.nix
+++ b/modules/monitoring/loki.nix
@@ -7,6 +7,16 @@ let
   wgAdminAddr = config.networking.sbee.hosts.rho.wg-admin;
 in
 {
+  imports = [ ../gatus/check.nix ];
+
+  gatusCheck.push = [
+    {
+      name = "Loki";
+      group = "monitoring";
+      url = "http://127.0.0.1:3100/ready";
+    }
+  ];
+
   services.loki = {
     enable = true;
     configuration = {

--- a/modules/monitoring/vector/monitor-systems.nix
+++ b/modules/monitoring/vector/monitor-systems.nix
@@ -12,6 +12,15 @@ in
     ../loki.nix
     ../grafana.nix
     ../prometheus
+    ../../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "Prometheus";
+      group = "monitoring";
+      url = "http://127.0.0.1:9090/-/healthy";
+    }
   ];
 
   services.vector.settings.sinks = {

--- a/modules/n8n/default.nix
+++ b/modules/n8n/default.nix
@@ -54,7 +54,18 @@ let
   '';
 in
 {
-  imports = [ ../acme/sync.nix ];
+  imports = [
+    ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "n8n";
+      group = "apps";
+      url = "http://127.0.0.1:5678/healthz";
+    }
+  ];
 
   acmeSyncer.mkReceiver = [
     {

--- a/modules/n8n/reverse-proxy.nix
+++ b/modules/n8n/reverse-proxy.nix
@@ -12,6 +12,15 @@ in
   imports = [
     ../acme
     ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "n8n (webhook)";
+      url = "https://n8n.sjanglab.org/healthz";
+      group = "apps";
+    }
   ];
 
   acmeSyncer.mkSender = [

--- a/modules/nextcloud/default.nix
+++ b/modules/nextcloud/default.nix
@@ -11,7 +11,19 @@ let
   certDir = "/var/lib/acme/${domain}";
 in
 {
-  imports = [ ../acme/sync.nix ];
+  imports = [
+    ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "Nextcloud";
+      group = "apps";
+      url = "http://127.0.0.1:80/status.php";
+      expectedStatus = 301;
+    }
+  ];
 
   acmeSyncer.mkReceiver = [
     { inherit domain; }

--- a/modules/ntfy.nix
+++ b/modules/ntfy.nix
@@ -29,11 +29,8 @@
       listen-http = "127.0.0.1:2586";
       behind-proxy = true;
 
-      auth-users = [
-        "mulatta:$2b$12$EdDkCKfL2BL35SdzCFznBe2xm8jOL9IM6IaH3nlZV6UQ70j/iGOZ2:admin"
-      ];
-      auth-access = [
-      ];
+      # Admin user managed in auth-file DB (/var/lib/ntfy/user.db)
+      # Provision: ntfy user add --role=admin <username>
       auth-default-access = "deny-all";
       auth-file = "/var/lib/ntfy/user.db";
 

--- a/modules/ntfy.nix
+++ b/modules/ntfy.nix
@@ -72,11 +72,12 @@
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
+    group = "nginx";
   };
 
   services.nginx.virtualHosts."ntfy.sjanglab.org" = {
     forceSSL = true;
-    enableACME = true;
+    useACMEHost = "ntfy.sjanglab.org";
 
     locations."/" = {
       proxyPass = "http://127.0.0.1:2586";

--- a/modules/ntfy.nix
+++ b/modules/ntfy.nix
@@ -5,7 +5,19 @@
   ...
 }:
 {
-  imports = [ ./acme ];
+  imports = [
+    ./acme
+    ./gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "ntfy";
+      url = "https://ntfy.sjanglab.org/v1/health";
+      group = "infra";
+    }
+  ];
+
   services.ntfy-sh = {
     enable = true;
     package = pkgs.ntfy-sh;

--- a/modules/ollama/default.nix
+++ b/modules/ollama/default.nix
@@ -6,10 +6,10 @@
 }:
 let
   inherit (config.networking.sbee) hosts;
+  authentikAuth = import ../authentik/nginx-locations.nix { inherit hosts; };
   port = 11434;
   domain = "ollama.sjanglab.org";
   certDir = "/var/lib/acme/${domain}";
-  authentikOutpost = "http://${hosts.eta.wg-admin}:9000";
 in
 {
   imports = [
@@ -97,60 +97,27 @@ in
       sslCertificate = "${certDir}/fullchain.pem";
       sslCertificateKey = "${certDir}/key.pem";
 
-      # Authentik outpost - auth endpoint (internal, for auth_request)
-      locations."/outpost.goauthentik.io/auth/nginx" = {
-        proxyPass = "${authentikOutpost}/outpost.goauthentik.io/auth/nginx";
-        extraConfig = ''
-          internal;
-          proxy_pass_request_body off;
-          proxy_set_header Content-Length "";
-          proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
-          proxy_set_header Authorization $http_authorization;
-        '';
-      };
+      locations = authentikAuth.locations // {
+        "/" = {
+          proxyPass = "http://127.0.0.1:${toString port}";
+          recommendedProxySettings = false; # Override Host header manually
+          extraConfig = authentikAuth.protectLocation + ''
 
-      # Authentik outpost - start/callback (external, for redirects)
-      locations."/outpost.goauthentik.io" = {
-        proxyPass = "${authentikOutpost}/outpost.goauthentik.io";
-        extraConfig = ''
-          proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
-          proxy_set_header Authorization $http_authorization;
-        '';
-      };
+            # Override Host header for ollama
+            proxy_set_header Host 127.0.0.1:${toString port};
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
 
-      # Signin redirect - same domain, not auth.sjanglab.org
-      locations."@authentik_signin" = {
-        extraConfig = ''
-          internal;
-          return 302 /outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri;
-        '';
-      };
+            # Ollama streaming responses
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
 
-      # Main location - protected by Authentik forward auth
-      locations."/" = {
-        proxyPass = "http://127.0.0.1:${toString port}";
-        recommendedProxySettings = false; # Override Host header manually
-        extraConfig = ''
-          # Authentik forward auth
-          auth_request /outpost.goauthentik.io/auth/nginx;
-          auth_request_set $authentik_email $upstream_http_x_authentik_email;
-          error_page 401 = @authentik_signin;
-          proxy_set_header X-authentik-email $authentik_email;
-
-          # Override Host header for ollama
-          proxy_set_header Host 127.0.0.1:${toString port};
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
-
-          # Ollama streaming responses
-          proxy_buffering off;
-          proxy_read_timeout 600s;
-          proxy_send_timeout 600s;
-
-          # Large model responses
-          client_max_body_size 100M;
-        '';
+            # Large model responses
+            client_max_body_size 100M;
+          '';
+        };
       };
     };
   };

--- a/modules/ollama/default.nix
+++ b/modules/ollama/default.nix
@@ -12,7 +12,18 @@ let
   authentikOutpost = "http://${hosts.eta.wg-admin}:9000";
 in
 {
-  imports = [ ../acme/sync.nix ];
+  imports = [
+    ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "Ollama";
+      group = "ai";
+      url = "http://127.0.0.1:${toString port}";
+    }
+  ];
 
   acmeSyncer.mkReceiver = [
     {

--- a/modules/postgresql/default.nix
+++ b/modules/postgresql/default.nix
@@ -8,6 +8,16 @@ let
   inherit (config.networking.sbee) currentHost hosts;
 in
 {
+  imports = [ ../gatus/check.nix ];
+
+  gatusCheck.push = [
+    {
+      name = "PostgreSQL";
+      group = "db";
+      systemdService = "postgresql.service";
+    }
+  ];
+
   services.postgresql = {
     enable = true;
     package = pkgs.postgresql_17;

--- a/modules/vaultwarden/default.nix
+++ b/modules/vaultwarden/default.nix
@@ -51,12 +51,13 @@
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;
+    group = "nginx";
   };
 
   # Nginx reverse proxy
   services.nginx.virtualHosts."vault.sjanglab.org" = {
     forceSSL = true;
-    enableACME = true;
+    useACMEHost = "vault.sjanglab.org";
 
     locations."/" = {
       proxyPass = "http://127.0.0.1:8000";

--- a/modules/vaultwarden/default.nix
+++ b/modules/vaultwarden/default.nix
@@ -1,6 +1,17 @@
 { config, ... }:
 {
-  imports = [ ../acme ];
+  imports = [
+    ../acme
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.pull = [
+    {
+      name = "Vaultwarden";
+      url = "https://vault.sjanglab.org/alive";
+      group = "apps";
+    }
+  ];
 
   services.vaultwarden = {
     enable = true;

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -114,6 +114,16 @@ resource "cloudflare_dns_record" "vaultwarden" {
   comment = "Vaultwarden password manager"
 }
 
+resource "cloudflare_dns_record" "gatus" {
+  zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
+  name    = "gatus.sjanglab.org"
+  content = "141.164.53.203"
+  type    = "A"
+  ttl     = 300
+  proxied = false
+  comment = "Gatus status monitoring"
+}
+
 resource "cloudflare_dns_record" "n8n" {
   zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
   name    = "n8n.sjanglab.org"


### PR DESCRIPTION
- **feat(gatus): add health monitoring with hybrid pull/push architecture**
- **security(ntfy): remove hardcoded bcrypt auth credential**
- **fix(acme): use useACMEHost for DNS challenge certs**
- **fix(gatus): add push endpoint validation and script hardening**
- **refactor(nginx): extract shared Authentik forward auth locations**
- **style: document security decisions and remove with-lib antipattern**
