### PR TITLE
psi: drop clickhouse

### DIFF
--- a/hosts/psi.nix
+++ b/hosts/psi.nix
@@ -18,7 +18,6 @@
     ../modules/icebox/databases.nix
     ../modules/docling
     ../modules/tei
-    ../modules/clickhouse
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-Samsung_SSD_990_PRO_4TB_S7DPNU0Y404280K";


### PR DESCRIPTION
- clickhouse-server as a service is not useful
- use clickhouse as a process-composer in your project
