### PR TITLE
fix(buildbot): add Restart=on-failure to buildbot-master

### DIFF
--- a/modules/buildbot/master.nix
+++ b/modules/buildbot/master.nix
@@ -72,9 +72,13 @@ in
     PGPASSFILE = config.sops.secrets.buildbot-pgpass.path;
   };
 
-  systemd.services.buildbot-master.serviceConfig.LoadCredential = [
-    "niks3-auth-token:${config.sops.secrets.niks3-auth-token.path}"
-  ];
+  systemd.services.buildbot-master.serviceConfig = {
+    LoadCredential = [
+      "niks3-auth-token:${config.sops.secrets.niks3-auth-token.path}"
+    ];
+    Restart = "on-failure";
+    RestartSec = "30s";
+  };
 
   services.buildbot-master.extraConfig = ''
     c["www"]["port"] = "tcp:8010:interface=${hosts.psi.wg-admin}"


### PR DESCRIPTION
DB 연결 실패 시 서비스가 죽은 채로 방치되는 문제 방지.
rho의 PostgreSQL이 늦게 뜨면 master가 크래시 후 복구 안 됨.
