### PR TITLE
wireguard: require admin recovery peers

### DIFF
--- a/configurations.nix
+++ b/configurations.nix
@@ -50,6 +50,7 @@ let
     ./modules/nix-index.nix
     ./modules/packages.nix
     ./modules/register-flake.nix
+    ./modules/remote-builder.nix
     ./modules/sshd
     ./modules/users/admins.nix
     ./modules/users/extra-user-options.nix

--- a/modules/remote-builder.nix
+++ b/modules/remote-builder.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+let
+  inherit (config.networking) hostName;
+
+  # Private half lives outside infra in the dots clan var
+  # psi-builder/ssh-key. It is used by the root nix-daemon on rhesus, not by
+  # interactive admin SSH, so keep it separate from the Secretive admin key.
+  builderPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGf6fKb1r0vzdHyLRyoJ5TgFG8PkL3UQw8nISGJWUdMF seungwon@rhesus";
+
+  # eta is only a WireGuard jump from rhesus to psi's SSH port. The source and
+  # destination limits keep this key from becoming a general-purpose bastion key.
+  etaJumpKey = ''from="10.100.0.200",restrict,port-forwarding,permitopen="10.100.0.2:10022" ${builderPublicKey}'';
+
+  # psi runs the actual Nix builder, so command execution is intentionally
+  # allowed, but only when the connection arrives from eta over wg-admin.
+  psiBuilderKey = ''from="10.100.0.1" ${builderPublicKey}'';
+in
+{
+  users.users.root.openssh.authorizedKeys.keys =
+    lib.optionals (hostName == "eta") [ etaJumpKey ]
+    ++ lib.optionals (hostName == "psi") [ psiBuilderKey ];
+}

--- a/modules/wireguard/admin-access.nix
+++ b/modules/wireguard/admin-access.nix
@@ -1,0 +1,73 @@
+{ config, lib, ... }:
+let
+  cfg = config.networking.sbee;
+
+  adminPeers = cfg.adminWireguardPeers;
+  adminUsers = lib.filterAttrs (
+    _name: user: user.isNormalUser && builtins.elem "admin" user.extraGroups
+  ) config.users.users;
+  adminUserNames = builtins.attrNames adminUsers;
+  peerOwners = lib.mapAttrsToList (_name: peer: peer.owner) adminPeers;
+  peerAddresses = lib.mapAttrsToList (_name: peer: peer.address) adminPeers;
+  machineWgAddresses = lib.filter (addr: addr != null) (
+    lib.mapAttrsToList (_name: host: host.wg-admin) cfg.hosts
+  );
+in
+{
+  options.networking.sbee.adminWireguardPeers = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          owner = lib.mkOption {
+            type = lib.types.str;
+            description = "Admin user that owns this WireGuard peer.";
+          };
+          address = lib.mkOption {
+            type = lib.types.str;
+            description = "Unique wg-admin IPv4 address without CIDR.";
+          };
+          publicKey = lib.mkOption {
+            type = lib.types.str;
+            description = "WireGuard public key for the admin-owned device.";
+          };
+        };
+      }
+    );
+    default = { };
+    description = "Admin-owned WireGuard peers allowed on the wg-admin network.";
+  };
+
+  config = {
+    networking.sbee.adminWireguardPeers = {
+      seungwon-rhesus = {
+        owner = "seungwon";
+        address = "10.100.0.200";
+        publicKey = "EeRAyghu9jCEIwiuVEXtkfi9WrEyr+TuqnCgIHktGWg=";
+      };
+    };
+
+    networking.sbee.wireguard.wg-admin.peers = lib.mapAttrsToList (_name: peer: {
+      PublicKey = peer.publicKey;
+      AllowedIPs = [ "${peer.address}/32" ];
+    }) adminPeers;
+
+    assertions = [
+      {
+        assertion = lib.all (name: builtins.elem name peerOwners) adminUserNames;
+        message = "Every admin user must own at least one networking.sbee.adminWireguardPeers entry.";
+      }
+      {
+        assertion = lib.all (owner: builtins.hasAttr owner adminUsers) peerOwners;
+        message = "Every admin WireGuard peer owner must be an admin user.";
+      }
+      {
+        assertion = (builtins.length peerAddresses) == (builtins.length (lib.unique peerAddresses));
+        message = "Admin WireGuard peer addresses must be unique.";
+      }
+      {
+        assertion = lib.all (address: !(builtins.elem address machineWgAddresses)) peerAddresses;
+        message = "Admin WireGuard peer addresses must not overlap machine wg-admin addresses.";
+      }
+    ];
+  };
+}

--- a/modules/wireguard/default.nix
+++ b/modules/wireguard/default.nix
@@ -1,30 +1,14 @@
 {
-  config,
   lib,
   pkgs,
   ...
 }:
-let
-  cfg = config.networking.sbee.currentHost;
-  inherit (config.networking.sbee) others;
-
-  hasTag = host: tag: builtins.elem tag (host.tags or [ ]);
-  currentHasTag = tag: hasTag cfg tag;
-
-  mkPeer =
-    interface: port: hostName: host:
-    lib.filterAttrs (_n: v: v != null) {
-      PublicKey = builtins.readFile (./keys + "/${hostName}_${interface}");
-      Endpoint =
-        if ((currentHasTag "public-ip") && (hasTag host "nat-behind")) then
-          null
-        else
-          "${host.ipv4}:${builtins.toString port}";
-      AllowedIPs = [ "${host.${interface}}/32" ];
-      PersistentKeepalive = 25;
-    };
-in
 {
+  imports = [
+    ./machines.nix
+    ./admin-access.nix
+  ];
+
   options = with lib; {
     networking.sbee.wireguard = mkOption {
       type =
@@ -45,6 +29,7 @@ in
             };
             peers = mkOption {
               type = listOf attrs;
+              default = [ ];
               description = "WireGuard peer configurations";
             };
           };
@@ -53,17 +38,8 @@ in
       description = "WireGuard network configurations";
     };
   };
-  config = {
-    # wireguard configuration for current host
-    networking.sbee.wireguard = {
-      wg-admin = {
-        interface = "wg-admin";
-        port = 51820;
-        address = "${cfg.wg-admin}/24";
-        peers = lib.mapAttrsToList (mkPeer "wg-admin" 51820) others;
-      };
-    };
 
+  config = {
     sops.secrets = {
       "wg-admin-key" = {
         mode = "0400";

--- a/modules/wireguard/machines.nix
+++ b/modules/wireguard/machines.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+let
+  cfg = config.networking.sbee.currentHost;
+  inherit (config.networking.sbee) others;
+
+  hasTag = host: tag: builtins.elem tag (host.tags or [ ]);
+  currentHasTag = tag: hasTag cfg tag;
+
+  mkPeer =
+    interface: port: hostName: host:
+    lib.filterAttrs (_n: v: v != null) {
+      PublicKey = builtins.readFile (./keys + "/${hostName}_${interface}");
+      Endpoint =
+        if ((currentHasTag "public-ip") && (hasTag host "nat-behind")) then
+          null
+        else
+          "${host.ipv4}:${builtins.toString port}";
+      AllowedIPs = [ "${host.${interface}}/32" ];
+      PersistentKeepalive = 25;
+    };
+in
+{
+  networking.sbee.wireguard.wg-admin = {
+    interface = "wg-admin";
+    port = 51820;
+    address = "${cfg.wg-admin}/24";
+    peers = lib.mapAttrsToList (mkPeer "wg-admin" 51820) others;
+  };
+}

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@
 import json
 import os
 import random
+import re
 import shlex
 import string
 import subprocess
@@ -293,6 +294,92 @@ def generate_wireguard_key(c: Any, hostname: str) -> None:
 
         c.run(f"sops --set '[\"wg-admin-key\"] {json.dumps(wg_key)}' {ROOT}/hosts/{hostname}.yaml")
         c.run(f"echo {wg_pubkey} > {ROOT}/modules/wireguard/keys/{hostname}_wg-admin")
+
+
+@task
+def generate_admin_wireguard_key(
+    c: Any,
+    owner: str,
+    device: str,
+    address: str,
+    output_dir: str = ".",
+) -> None:
+    """
+    Generate an admin WireGuard key and client config.
+
+    Example:
+      inv generate-admin-wireguard-key --owner seungwon --device rhesus --address 10.100.0.200
+    """
+    name = f"{owner}-{device}"
+    if re.fullmatch(r"[A-Za-z0-9_-]+", name) is None:
+        raise ValueError("owner and device may only contain letters, numbers, '_' and '-'")
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    config_path = out_dir / f"{name}-wg-admin.conf"
+    if config_path.exists():
+        raise FileExistsError(f"Refusing to overwrite {config_path}")
+
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        c.run(
+            "nix shell --inputs-from . nixpkgs#wireguard-tools -c sh -c "
+            + shlex.quote(
+                f"umask 077 && wg genkey > {tmp_path / 'private'} "
+                f"&& wg pubkey < {tmp_path / 'private'} > {tmp_path / 'public'}"
+            ),
+            echo=True,
+        )
+        private_key = (tmp_path / "private").read_text().strip()
+        public_key = (tmp_path / "public").read_text().strip()
+
+    hosts = json.loads(
+        c.run(
+            "nix eval --json .#nixosConfigurations.eta.config.networking.sbee.hosts",
+            hide=True,
+        ).stdout
+    )
+
+    peer_blocks = []
+    for host_name, host in sorted(hosts.items()):
+        if "public-ip" not in host.get("tags", []) or host.get("wg-admin") is None:
+            continue
+        host_key = ROOT / "modules" / "wireguard" / "keys" / f"{host_name}_wg-admin"
+        if not host_key.exists():
+            continue
+        peer_blocks.append(
+            "\n".join(
+                [
+                    "[Peer]",
+                    f"PublicKey = {host_key.read_text().strip()}",
+                    f"Endpoint = {host['ipv4']}:51820",
+                    f"AllowedIPs = {host['wg-admin']}/32",
+                    "PersistentKeepalive = 25",
+                ]
+            )
+        )
+
+    interface_block = "\n".join(
+        [
+            "[Interface]",
+            f"PrivateKey = {private_key}",
+            f"Address = {address}/32",
+        ]
+    )
+    config = "\n\n".join([interface_block, *peer_blocks])
+    old_umask = os.umask(0o077)
+    try:
+        config_path.write_text(config + "\n")
+    finally:
+        os.umask(old_umask)
+
+    print(f"Wrote private client config: {config_path}")
+    print("\nAdd this public peer to modules/wireguard/admin-access.nix:")
+    print(f"  {name} = {{")
+    print(f"    owner = {json.dumps(owner)};")
+    print(f"    address = {json.dumps(address)};")
+    print(f"    publicKey = {json.dumps(public_key)};")
+    print("  };")
 
 
 @task


### PR DESCRIPTION

Keep administrative access independent from public SSH bans so operators can recover when fail2ban blocks normal users. Split machine peers from admin device peers and provide a generator that keeps private client keys out of the repo.



remote-builder: authorize the daemon key

Let the non-interactive Nix daemon use its dedicated builder key over the WireGuard jump path instead of relying on the interactive Secretive admin key. Limit the eta hop to the rhesus WireGuard address and the psi SSH target so the key cannot be used as a general public bastion credential.


