### PR TITLE
project-space: provide a shared project directory

### DIFF
--- a/modules/project-space.nix
+++ b/modules/project-space.nix
@@ -12,6 +12,7 @@
     let
       loginUsers = lib.filterAttrs (_n: v: v.isNormalUser || v.name == "root") config.users.users;
     in
-    (lib.mapAttrsToList (n: _v: "d /project/${n} 0755 ${n} users -") loginUsers)
+    [ "d /project/shared 0775 root users -" ]
+    ++ (lib.mapAttrsToList (n: _v: "d /project/${n} 0755 ${n} users -") loginUsers)
     ++ (builtins.map (n: "R /project/${n} - - - - -") config.users.deletedUsers);
 }


### PR DESCRIPTION

Create a common backed-up workspace so users can exchange long-lived project data without relying on per-user directories.


