### PR TITLE
buildbot: use local Postgres socket

### DIFF
--- a/modules/buildbot/database.nix
+++ b/modules/buildbot/database.nix
@@ -5,10 +5,6 @@
   pkgs,
   ...
 }:
-let
-  inherit (config.networking.sbee) hosts;
-  psql = "${config.services.postgresql.package}/bin/psql --port=${toString config.services.postgresql.settings.port}";
-in
 {
   imports = [ ../gatus/check.nix ];
 
@@ -25,7 +21,7 @@ in
     package = pkgs.postgresql_17;
 
     settings = {
-      listen_addresses = lib.mkForce hosts.psi.wg-admin;
+      listen_addresses = lib.mkForce "localhost";
       port = 5432;
     };
 
@@ -36,14 +32,14 @@ in
         ensureDBOwnership = true;
       }
     ];
-    authentication = lib.mkAfter ''
-      host buildbot buildbot ${hosts.psi.wg-admin}/32 scram-sha-256
-    '';
   };
 
   systemd.services.postgresql-setup.postStart = lib.mkAfter ''
     BUILDBOT_PW=$(cat ${config.sops.secrets.buildbot-db-password.path})
-    ${psql} -tAc "ALTER USER buildbot WITH PASSWORD '$BUILDBOT_PW'" -d postgres
+    ${config.services.postgresql.package}/bin/psql \
+      --port=${toString config.services.postgresql.settings.port} \
+      -tAc "ALTER USER buildbot WITH PASSWORD '$BUILDBOT_PW'" \
+      -d postgres
   '';
 
   sops.secrets.buildbot-db-password = {
@@ -53,6 +49,4 @@ in
   };
 
   services.postgresqlBackup.databases = lib.mkAfter [ "buildbot" ];
-
-  networking.firewall.interfaces.wg-admin.allowedTCPPorts = [ 5432 ];
 }

--- a/modules/buildbot/master.nix
+++ b/modules/buildbot/master.nix
@@ -65,11 +65,15 @@ in
     admins = [ "mulatta" ];
   };
 
-  services.buildbot-master.dbUrl = lib.mkForce "postgresql://buildbot@${hosts.psi.wg-admin}/buildbot";
+  services.buildbot-master.dbUrl = lib.mkForce "postgresql://buildbot@/buildbot?host=/run/postgresql";
   services.buildbot-master.buildbotUrl = lib.mkForce "https://${buildbotDomain}/";
 
-  systemd.services.buildbot-master.environment = {
-    PGPASSFILE = config.sops.secrets.buildbot-pgpass.path;
+  systemd.services.buildbot-master = {
+    after = [ "postgresql.service" ];
+    requires = [ "postgresql.service" ];
+    environment = {
+      PGPASSFILE = config.sops.secrets.buildbot-pgpass.path;
+    };
   };
 
   systemd.services.buildbot-master.serviceConfig = {


### PR DESCRIPTION

Buildbot and its database run on psi, so binding Postgres to wg-admin only makes boot depend on WireGuard address timing. Use the local socket and keep only the worker protocol exposed on wg-admin.


