### PR TITLE
nixpkgs: bump systems to 26.05

### DIFF
--- a/configurations.nix
+++ b/configurations.nix
@@ -83,10 +83,6 @@ let
         sops.defaultSopsFile = lib.mkIf (builtins.pathExists sopsFile) sopsFile;
         time.timeZone = lib.mkForce "Asia/Seoul";
 
-        # WARN: patch Copy Fail (CVE-2026-31431)
-        boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.18.22") (
-          lib.mkDefault pkgs.linuxPackages_6_18
-        );
       }
     )
   ];

--- a/flake.lock
+++ b/flake.lock
@@ -260,16 +260,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782498288,
-        "narHash": "sha256-8/X3yyTXiE82b38n32ItbOqfWOVBl+gKa8fILyZfR4Q=",
+        "lastModified": 1782691344,
+        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cac626ec5e3703e835f227687e88aa9e2f25701",
+        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Shared roots. Other flakes follow these to avoid duplicate lock nodes.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-parts = {

--- a/modules/gatus/check.nix
+++ b/modules/gatus/check.nix
@@ -43,8 +43,11 @@ let
           fi
           ${pkgs.curl}/bin/curl -sf --max-time 10 \
             -X POST \
+            -G \
+            --data-urlencode "success=$success" \
+            --data-urlencode "error=$error" \
             -H "Authorization: Bearer $GATUS_EXTERNAL_TOKEN" \
-            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external?success=$success&error=$error"
+            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external"
         ''
       else
         ''
@@ -59,8 +62,11 @@ let
           fi
           ${pkgs.curl}/bin/curl -sf --max-time 10 \
             -X POST \
+            -G \
+            --data-urlencode "success=$success" \
+            --data-urlencode "error=$error" \
             -H "Authorization: Bearer $GATUS_EXTERNAL_TOKEN" \
-            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external?success=$success&error=$error"
+            "${gatusApi}/api/v1/endpoints/${mkKey ep}/external"
         ''
     );
 

--- a/modules/harmonia/default.nix
+++ b/modules/harmonia/default.nix
@@ -9,7 +9,7 @@ in
 {
   environment.systemPackages = [ pkgs.harmonia ];
 
-  services.harmonia = {
+  services.harmonia.cache = {
     enable = true;
 
     signKeyPaths = [ config.sops.secrets.harmonia-sign-key.path ];
@@ -22,7 +22,9 @@ in
 
   sops.secrets.harmonia-sign-key = {
     sopsFile = ./secrets.yaml;
-    owner = "harmonia";
+    owner = "root";
+    group = "root";
+    mode = "0400";
   };
 
   # Allow nix-daemon to read store for harmonia

--- a/modules/headscale/secrets.yaml
+++ b/modules/headscale/secrets.yaml
@@ -1,9 +1,8 @@
 headscale-oidc-secret: ENC[AES256_GCM,data:Zn+KSfBE2p3/5HuhfJpuq46MYt5BNHkbv3+xTgQ/qg6pB9ecMpDhLxnFP4P5yHYHSzuI7kS6+jJVcdDBzs4FeHDokLrMh2yrbdMVbMIqPevwdjhZ0I9NSLV1A+3y5PrqL4fRytm0xW8jZFrWVBrwnVG2kQiB28CDF9b07ooLFCo=,iv:LFEgsnqAGBb5QMToQy4wP32LIkg46wrb/dYbxJYSYms=,tag:EfCyYfo2DN73w8DLu4oNKw==,type:str]
-authentik-api-token: ENC[AES256_GCM,data:vyUt2G1/Fd72r39ZLdb81YbcFW8l3R59AFw61E3azAocMH1Bz059aWyrhhI78je/4II1dLbZS7NyKQGa,iv:4WlR77aZzXATtwqDw42alQzZ1iJjDdUrU4xYdy0HChA=,tag:t+c3uGLckzXVgppzrZdzRA==,type:str]
+authentik-api-token: ENC[AES256_GCM,data:wQMGw5I/ZHmJxV/Uwi06RRMWu5krr6JJN/alMu+iF4aA6LPpGlIphbepjWcItWltJ4svXcOpG/Qkq5DH,iv:3oeW79EmZKRXGU8D5AgIDqFLp+Y4McYOM4VQz7etGRs=,tag:TQ+YeprHWrcXQ8EE0a4MZQ==,type:str]
 sops:
     age:
-        - recipient: age1zdhqm6ptcnuu3tf2lzcngqmf6eud7jfah7v8falfy5mdksmnfuzq35sq54
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSTlNnZWs0a0RGZ1E3MFVh
             RTRKRnNIYmtLbG82VFhNR2llclNxODJzYTNnCkxaekFJNTRQWXZtYVZaenM5WmpG
@@ -11,8 +10,8 @@ sops:
             bnhIVFJCUXZiVXFnbC8vTXVENmc3elEK/Z2fE7+x471fKL4Pv+VJsNpr3EjzhhiW
             vPKXnz2QEO9XKlVYczcenAu8C29gO9a0fpRgOqCgXvhzpC3PHA4rBw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1730f3cxdyh56zw8xcvlmpa7u2x7353wu4u0e58kyx24rsefgp98sxehm6s
-          enc: |
+          recipient: age1zdhqm6ptcnuu3tf2lzcngqmf6eud7jfah7v8falfy5mdksmnfuzq35sq54
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVc1VNRStVWDhsQnora3Q3
             eEY0dE8wV2dVQit6VlRaMmhqQTA3dWt2WENjClhldnl4VmJ2R1dRL0RjT2lvYWdz
@@ -20,7 +19,8 @@ sops:
             NEw3LzhOR3N6cHkzazRUZDU2MFlZRUUKd/aNg5YhwhJYQF37SZVmkxwQBDc3o5L+
             FOjkKKLhKGMwSv15cj9BnnGV2xPz8c/o8QXjvLTjZOjZjStRwPL7yg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-03T13:02:46Z"
-    mac: ENC[AES256_GCM,data:PEH+o7Jv6Bz0w67/E11RjhEhitUimDikMv5Zz5Lzb/oo1Rxpoo9nfRVGY18U6uSRZlVnnL3R0itnCU0dpnoGgBZyg30mZ3qo/DQ3uiCU8zEA2wgLXkpKQYLfX2k7bAPya3UYlCJS1oPJ0PXemofIv2Bo+xeJLZd+gZ9NoM2ap/s=,iv:VTSxHYRejU6QKPxDUyjYYxkOTSUq2yulEOKwEP73CK4=,tag:34GoP3l7ClpICIthF5ZQlg==,type:str]
+          recipient: age1730f3cxdyh56zw8xcvlmpa7u2x7353wu4u0e58kyx24rsefgp98sxehm6s
+    lastmodified: "2026-06-30T17:40:02Z"
+    mac: ENC[AES256_GCM,data:AFeOwyrddviE69yyDJv8MrDyied4ZS0kEQ/DmM7Ye6OMwBqi6tSa+zOhDpzA41MJFOSmuxIKNyXRfdTyZ32VhMLz+mLKdPWxc80AQqAUN6r/xFZFb0R3WTzzdBzyQmjmKqnRd89xi2EZ0QCu9Lfahxomptw1sXEQ5T6d8Rs2+iM=,iv:DSNe742MAdWXpQ8vbMPGGjwLHe/DGXapDvrL30ZWgpM=,tag:NoY0l7vO1bjCf1gmI1bfBQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.13.1

--- a/modules/monitoring/grafana.nix
+++ b/modules/monitoring/grafana.nix
@@ -16,7 +16,7 @@ in
     {
       name = "Grafana";
       group = "monitoring";
-      url = "http://127.0.0.1:3000/api/health";
+      url = "http://${wgAdminAddr}:3000/api/health";
     }
   ];
 

--- a/modules/monitoring/loki.nix
+++ b/modules/monitoring/loki.nix
@@ -13,7 +13,7 @@ in
     {
       name = "Loki";
       group = "monitoring";
-      url = "http://127.0.0.1:3100/ready";
+      url = "http://${wgAdminAddr}:3100/ready";
     }
   ];
 

--- a/modules/monitoring/vector/monitor-systems.nix
+++ b/modules/monitoring/vector/monitor-systems.nix
@@ -19,7 +19,7 @@ in
     {
       name = "Prometheus";
       group = "monitoring";
-      url = "http://127.0.0.1:9090/-/healthy";
+      url = "http://${wgAdminAddr}:9090/-/healthy";
     }
   ];
 

--- a/modules/n8n/default.nix
+++ b/modules/n8n/default.nix
@@ -105,18 +105,14 @@ in
       DB_POSTGRESDB_DATABASE = "n8n";
       DB_POSTGRESDB_USER = "n8n";
 
-      # Password via _FILE suffix (read from systemd credentials)
-      DB_POSTGRESDB_PASSWORD_FILE = "%d/db-password";
+      # NixOS 26.05 maps *_FILE values to systemd credentials for DynamicUser.
+      DB_POSTGRESDB_PASSWORD_FILE = config.sops.secrets.n8n-db-password.path;
     };
   };
 
   sops.secrets.n8n-db-password = {
     sopsFile = ./secrets.yaml;
   };
-
-  systemd.services.n8n.serviceConfig.LoadCredential = [
-    "db-password:${config.sops.secrets.n8n-db-password.path}"
-  ];
 
   # Firewall: wg-admin (for eta reverse proxy)
   networking.firewall.interfaces.wg-admin.allowedTCPPorts = [ 5678 ];

--- a/modules/nextcloud/default.nix
+++ b/modules/nextcloud/default.nix
@@ -31,7 +31,7 @@ in
 
   services.nextcloud = {
     enable = true;
-    package = pkgs.nextcloud32;
+    package = pkgs.nextcloud33;
     hostName = domain;
     https = true;
 

--- a/modules/sshd/default.nix
+++ b/modules/sshd/default.nix
@@ -52,7 +52,7 @@ in
       LoginGraceTime = ssh.loginGraceTime;
 
       PermitUserEnvironment = false;
-      AcceptEnv = "NIKS3_SERVER_URL";
+      AcceptEnv = [ "NIKS3_SERVER_URL" ];
       Compression = false;
 
       TCPKeepAlive = true;


### PR DESCRIPTION
This bumps the production NixOS input from 25.11 to 26.05 so current srvos can use the resolved module interface expected by its server profile, instead of failing evaluation on services.resolved.settings. The follow-up changes adapt local 26.05 option changes for OpenSSH AcceptEnv and Harmonia cache/signing-key handling while preserving the existing NIKS3_SERVER_URL pass-through and Harmonia binary cache behavior. Verified with nix fmt and NixOS evaluation for eta, rho, tau, and psi; tau still reports the expected Nextcloud 26.05 upgrade warning.