### PR TITLE
zfs: avoid implicit root pool imports

### DIFF
--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -1,4 +1,7 @@
 {
   boot.loader.efi.canTouchEfiVariables = false;
   boot.loader.systemd-boot.enable = true;
+
+  # Avoid importing a stale root pool from another installation by default.
+  boot.zfs.forceImportRoot = false;
 }


### PR DESCRIPTION

Match the upcoming safer NixOS default so hosts do not automatically import stale root pools from another installation during boot.


