### PR TITLE
Move private services behind Headscale and Authentik

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,6 +148,27 @@
         "type": "github"
       }
     },
+    "multievolve-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix",
+        "uv2nix-env": "uv2nix-env"
+      },
+      "locked": {
+        "lastModified": 1782993998,
+        "narHash": "sha256-lMjTMaU3vB0hhGVHF6Q4kA+Ti5qYuUQbs6dtdq0VEgU=",
+        "owner": "mulatta",
+        "repo": "multievolve-nix",
+        "rev": "618b1f418073d4698c1eb1e4f41a2038dd8bb9ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mulatta",
+        "ref": "nixos-module-service",
+        "repo": "multievolve-nix",
+        "type": "github"
+      }
+    },
     "niks3": {
       "inputs": {
         "nixpkgs": [
@@ -260,16 +281,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847225,
-        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-26.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -290,6 +311,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1782847225,
+        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -302,6 +339,38 @@
         ],
         "uv2nix": [
           "authentik-nix",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems_2": {
+      "inputs": {
+        "nixpkgs": [
+          "multievolve-nix",
+          "uv2nix-env",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "multievolve-nix",
+          "uv2nix-env",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "multievolve-nix",
+          "uv2nix-env",
           "uv2nix"
         ]
       },
@@ -340,21 +409,44 @@
         "type": "github"
       }
     },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "multievolve-nix",
+          "uv2nix-env",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782808548,
+        "narHash": "sha256-9+XcLOzFo3tXSgH5xpd5g2i65cx4q6zvfNVEMV7hyEs=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "4de7c126c1a3e76e9ec9e3ced900aaa6d8847757",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "authentik-nix": "authentik-nix",
         "disko": "disko",
         "fast-nix-gc": "fast-nix-gc",
         "flake-parts": "flake-parts",
+        "multievolve-nix": "multievolve-nix",
         "niks3": "niks3",
         "nix-index-database": "nix-index-database",
         "nixbot": "nixbot",
         "nixos-images": "nixos-images",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix",
         "srvos": "srvos",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "sops-nix": {
@@ -415,6 +507,27 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "multievolve-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
           "nixpkgs"
         ]
       },
@@ -449,6 +562,61 @@
         "owner": "pyproject-nix",
         "repo": "uv2nix",
         "rev": "920fc6dfaf9f10ec56de93b184055e1a9f380d5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix-env": {
+      "inputs": {
+        "nixpkgs": [
+          "multievolve-nix",
+          "nixpkgs"
+        ],
+        "pyproject-build-systems": "pyproject-build-systems_2",
+        "pyproject-nix": "pyproject-nix_2",
+        "treefmt-nix": [
+          "multievolve-nix",
+          "treefmt-nix"
+        ],
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1782880978,
+        "narHash": "sha256-MewckjJGV0DV2X070b6T93FctV0D0DkDAg7aFfGXa8I=",
+        "owner": "mulatta",
+        "repo": "uv2nix-env",
+        "rev": "67a987d1ef13a7313dbbeea364ec71a443c3e8ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mulatta",
+        "repo": "uv2nix-env",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "multievolve-nix",
+          "uv2nix-env",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "multievolve-nix",
+          "uv2nix-env",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782810559,
+        "narHash": "sha256-loy132LKn8QfiPbFJhdTjm+yZG3zklyOQhVabLyx2l4=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "2f698e4b5a3c6004edaf051543542f18a36afe77",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,8 @@
     };
 
     # Applications.
+    multievolve-nix.url = "github:mulatta/multievolve-nix/nixos-module-service";
+
     niks3 = {
       url = "github:Mic92/niks3";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -36,6 +36,12 @@ in
       remoteHost = hosts.psi.wg-admin;
     }
     {
+      domain = "gatus.sjanglab.org";
+      serviceName = "acme-sync-gatus-to-rho";
+      remoteUser = "acme-sync-gatus";
+      remoteHost = hosts.rho.wg-admin;
+    }
+    {
       domain = "logging.sjanglab.org";
       serviceName = "acme-sync-logging-to-rho";
       remoteUser = "acme-sync-logging";
@@ -60,6 +66,13 @@ in
   };
 
   security.acme.certs."vllm.sjanglab.org" = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+    group = "acme";
+  };
+
+  security.acme.certs."gatus.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -14,7 +14,6 @@ in
     ../modules/uptermd
     ../modules/gatus
     ../modules/monitoring/vector
-    ../modules/monitoring/reverse-proxy.nix
     ../modules/n8n/reverse-proxy.nix
     ../modules/acme/sync.nix
   ];
@@ -37,6 +36,12 @@ in
       remoteHost = hosts.psi.wg-admin;
     }
     {
+      domain = "logging.sjanglab.org";
+      serviceName = "acme-sync-logging-to-rho";
+      remoteUser = "acme-sync-logging";
+      remoteHost = hosts.rho.wg-admin;
+    }
+    {
       domain = "vllm.sjanglab.org";
       serviceName = "acme-sync-vllm-to-psi";
       remoteUser = "acme-sync-vllm";
@@ -55,6 +60,13 @@ in
   };
 
   security.acme.certs."vllm.sjanglab.org" = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+    group = "acme";
+  };
+
+  security.acme.certs."logging.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -42,6 +42,12 @@ in
       remoteHost = hosts.rho.wg-admin;
     }
     {
+      domain = "multievolve.sjanglab.org";
+      serviceName = "acme-sync-multievolve-to-psi";
+      remoteUser = "acme-sync-multievolve";
+      remoteHost = hosts.psi.wg-admin;
+    }
+    {
       domain = "vault.sjanglab.org";
       serviceName = "acme-sync-vaultwarden-to-tau";
       remoteUser = "acme-sync-vaultwarden";
@@ -60,6 +66,13 @@ in
   };
 
   security.acme.certs."logging.sjanglab.org" = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+    group = "acme";
+  };
+
+  security.acme.certs."multievolve.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -48,6 +48,12 @@ in
       remoteHost = hosts.rho.wg-admin;
     }
     {
+      domain = "vault.sjanglab.org";
+      serviceName = "acme-sync-vaultwarden-to-tau";
+      remoteUser = "acme-sync-vaultwarden";
+      remoteHost = hosts.tau.wg-admin;
+    }
+    {
       domain = "vllm.sjanglab.org";
       serviceName = "acme-sync-vllm-to-psi";
       remoteUser = "acme-sync-vllm";
@@ -80,6 +86,13 @@ in
   };
 
   security.acme.certs."logging.sjanglab.org" = {
+    dnsProvider = "cloudflare";
+    environmentFile = config.sops.secrets.cloudflare-credentials.path;
+    webroot = null;
+    group = "acme";
+  };
+
+  security.acme.certs."vault.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;
     webroot = null;

--- a/hosts/eta.nix
+++ b/hosts/eta.nix
@@ -25,12 +25,6 @@ in
       remoteHost = hosts.tau.wg-admin;
     }
     {
-      domain = "ollama.sjanglab.org";
-      serviceName = "acme-sync-ollama-to-psi";
-      remoteUser = "acme-sync-ollama";
-      remoteHost = hosts.psi.wg-admin;
-    }
-    {
       domain = "docling.sjanglab.org";
       serviceName = "acme-sync-docling-to-psi";
       remoteHost = hosts.psi.wg-admin;
@@ -53,31 +47,11 @@ in
       remoteUser = "acme-sync-vaultwarden";
       remoteHost = hosts.tau.wg-admin;
     }
-    {
-      domain = "vllm.sjanglab.org";
-      serviceName = "acme-sync-vllm-to-psi";
-      remoteUser = "acme-sync-vllm";
-      remoteHost = hosts.psi.wg-admin;
-    }
   ];
 
   disko.rootDisk = "/dev/vda";
 
   # ACME certificates for internal services
-  security.acme.certs."ollama.sjanglab.org" = {
-    dnsProvider = "cloudflare";
-    environmentFile = config.sops.secrets.cloudflare-credentials.path;
-    webroot = null;
-    group = "acme";
-  };
-
-  security.acme.certs."vllm.sjanglab.org" = {
-    dnsProvider = "cloudflare";
-    environmentFile = config.sops.secrets.cloudflare-credentials.path;
-    webroot = null;
-    group = "acme";
-  };
-
   security.acme.certs."gatus.sjanglab.org" = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.secrets.cloudflare-credentials.path;

--- a/hosts/psi.nix
+++ b/hosts/psi.nix
@@ -15,6 +15,7 @@
     ../modules/borgbackup/psi/client.nix
     ../modules/monitoring/vector
     ../modules/harmonia
+    ../modules/multievolve
     # ../modules/vllm
     ../modules/db-sync/databases.nix
     ../modules/docling

--- a/hosts/rho.nix
+++ b/hosts/rho.nix
@@ -10,6 +10,7 @@
     ../modules/borgbackup/mirror.nix
     ../modules/monitoring/vector/monitor-systems.nix
     ../modules/monitoring/reverse-proxy.nix
+    ../modules/gatus/reverse-proxy.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-eui.00000000000000006479a79cdac0038a";

--- a/hosts/rho.nix
+++ b/hosts/rho.nix
@@ -9,6 +9,7 @@
     ../modules/borgbackup/rho/client.nix
     ../modules/borgbackup/mirror.nix
     ../modules/monitoring/vector/monitor-systems.nix
+    ../modules/monitoring/reverse-proxy.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-eui.00000000000000006479a79cdac0038a";

--- a/hosts/tau.nix
+++ b/hosts/tau.nix
@@ -11,6 +11,7 @@
     ../modules/monitoring/vector/monitor-services.nix
     ../modules/nextcloud
     ../modules/n8n
+    ../modules/vaultwarden/reverse-proxy.nix
   ];
 
   disko.rootDisk = "/dev/disk/by-id/nvme-eui.00000000000000006479a79cdac0038f";

--- a/modules/gatus/check.nix
+++ b/modules/gatus/check.nix
@@ -18,7 +18,7 @@
 }:
 let
   cfg = config.gatusCheck;
-  gatusApi = "https://gatus.sjanglab.org";
+  gatusApi = "http://${config.networking.sbee.hosts.eta.wg-admin}:8081";
 
   # Gatus external endpoint key: "${group}_${name}" with spaces/special chars → hyphens
   mkKey =
@@ -134,9 +134,6 @@ in
       assertion = (ep.url != null) != (ep.systemdService != null);
       message = "gatusCheck.push '${ep.name}': exactly one of 'url' or 'systemdService' must be set";
     }) cfg.push;
-
-    # Resolve gatus.sjanglab.org → eta WG IP for hosts behind NAT/WG
-    networking.hosts.${config.networking.sbee.hosts.eta.wg-admin} = [ "gatus.sjanglab.org" ];
 
     sops.secrets.gatus-push-token = {
       sopsFile = ./secrets.yaml;

--- a/modules/gatus/default.nix
+++ b/modules/gatus/default.nix
@@ -1,22 +1,21 @@
 { config, lib, ... }:
 let
   inherit (config.networking.sbee) hosts;
-  domain = "gatus.sjanglab.org";
   port = 8081; # 8080 is used by headscale
   systemCollector = hosts.rho.wg-admin;
   cfg = config.gatusCheck;
 in
 {
-  imports = [
-    ../acme
-    ./check.nix
-  ];
+  imports = [ ./check.nix ];
 
   services.gatus = {
     enable = true;
     environmentFile = config.sops.secrets.gatus-env.path;
     settings = {
-      web.port = port;
+      web = {
+        address = "0.0.0.0";
+        inherit port;
+      };
       metrics = true;
 
       security.basic = {
@@ -63,9 +62,7 @@ in
           # psi
           (mkExtEndpoint "Nixbot" "ci")
           (mkExtEndpoint "Nixbot PostgreSQL" "ci")
-          (mkExtEndpoint "Ollama" "ai")
           (mkExtEndpoint "Docling" "ai")
-          (mkExtEndpoint "vLLM" "ai")
           # tau
           (mkExtEndpoint "Nextcloud" "apps")
           (mkExtEndpoint "n8n" "apps")
@@ -80,30 +77,6 @@ in
 
   sops.secrets.gatus-env = {
     sopsFile = ./secrets.yaml;
-  };
-
-  # ACME certificate (DNS challenge via Cloudflare)
-  security.acme.certs.${domain} = {
-    dnsProvider = "cloudflare";
-    environmentFile = config.sops.secrets.cloudflare-credentials.path;
-    webroot = null;
-    group = "nginx";
-  };
-
-  # Nginx reverse proxy
-  services.nginx.virtualHosts.${domain} = {
-    forceSSL = true;
-    useACMEHost = domain;
-    locations."/" = {
-      proxyPass = "http://127.0.0.1:${toString port}";
-      proxyWebsockets = true;
-      extraConfig = ''
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-      '';
-    };
   };
 
   # Vector: scrape Gatus /metrics → push to rho Prometheus
@@ -123,8 +96,5 @@ in
     };
   };
 
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-  ];
+  networking.firewall.interfaces.wg-admin.allowedTCPPorts = [ port ];
 }

--- a/modules/gatus/reverse-proxy.nix
+++ b/modules/gatus/reverse-proxy.nix
@@ -1,0 +1,43 @@
+# Gatus tailnet reverse proxy (deployed on rho)
+{ config, ... }:
+let
+  inherit (config.networking.sbee) hosts;
+  authentikAuth = import ../authentik/nginx-locations.nix { inherit hosts; };
+  domain = "gatus.sjanglab.org";
+  certDir = "/var/lib/acme/${domain}";
+in
+{
+  imports = [ ../acme/sync.nix ];
+
+  acmeSyncer.mkReceiver = [
+    {
+      inherit domain;
+      user = "acme-sync-gatus";
+    }
+  ];
+
+  services.nginx = {
+    enable = true;
+
+    virtualHosts.${domain} = {
+      forceSSL = true;
+      sslCertificate = "${certDir}/fullchain.pem";
+      sslCertificateKey = "${certDir}/key.pem";
+
+      locations = authentikAuth.locations // {
+        "/" = {
+          proxyPass = "http://${hosts.eta.wg-admin}:8081";
+          proxyWebsockets = true;
+          extraConfig = authentikAuth.protectLocation + ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+      };
+    };
+  };
+
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 443 ];
+}

--- a/modules/headscale/acl-rules.nix
+++ b/modules/headscale/acl-rules.nix
@@ -26,6 +26,7 @@
         "tag:ai:443"
         "tag:apps:80"
         "tag:apps:443"
+        "tag:monitoring:443"
         "tag:monitoring:3000"
       ];
     }

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -67,6 +67,11 @@ in
             value = "100.64.0.2"; # rho headscale IP
           }
           {
+            name = "multievolve.sjanglab.org";
+            type = "A";
+            value = "100.64.0.1"; # psi headscale IP
+          }
+          {
             name = "vault.sjanglab.org";
             type = "A";
             value = "100.64.0.3"; # tau headscale IP

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -57,6 +57,11 @@ in
             value = "100.64.0.1"; # psi headscale IP
           }
           {
+            name = "logging.sjanglab.org";
+            type = "A";
+            value = "100.64.0.2"; # rho headscale IP
+          }
+          {
             name = "upterm.sjanglab.org";
             type = "A";
             value = "141.164.53.203"; # eta public IP

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -67,6 +67,11 @@ in
             value = "100.64.0.2"; # rho headscale IP
           }
           {
+            name = "vault.sjanglab.org";
+            type = "A";
+            value = "100.64.0.3"; # tau headscale IP
+          }
+          {
             name = "upterm.sjanglab.org";
             type = "A";
             value = "141.164.53.203"; # eta public IP

--- a/modules/headscale/default.nix
+++ b/modules/headscale/default.nix
@@ -57,6 +57,11 @@ in
             value = "100.64.0.1"; # psi headscale IP
           }
           {
+            name = "gatus.sjanglab.org";
+            type = "A";
+            value = "100.64.0.2"; # rho headscale IP
+          }
+          {
             name = "logging.sjanglab.org";
             type = "A";
             value = "100.64.0.2"; # rho headscale IP

--- a/modules/monitoring/reverse-proxy.nix
+++ b/modules/monitoring/reverse-proxy.nix
@@ -1,44 +1,55 @@
-# Grafana reverse proxy (deployed on eta)
-# Proxies requests to rho where Grafana is running on wg-admin
-{ config, ... }:
+# Grafana tailnet reverse proxy (deployed on rho)
+{
+  config,
+  ...
+}:
 let
-  inherit (config.networking.sbee) hosts;
+  inherit (config.networking.sbee) currentHost hosts;
+  authentikAuth = import ../authentik/nginx-locations.nix { inherit hosts; };
   loggingDomain = "logging.sjanglab.org";
+  certDir = "/var/lib/acme/${loggingDomain}";
 in
 {
-  imports = [ ../acme ];
+  imports = [ ../acme/sync.nix ];
 
-  services.nginx.virtualHosts.${loggingDomain} = {
-    forceSSL = true;
-    useACMEHost = loggingDomain;
+  acmeSyncer.mkReceiver = [
+    {
+      domain = loggingDomain;
+      user = "acme-sync-logging";
+    }
+  ];
 
-    locations = {
-      "/" = {
-        proxyPass = "http://${hosts.rho.wg-admin}:3000";
-        extraConfig = ''
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
-        '';
-      };
-      # Grafana live (WebSocket)
-      "/api/live/" = {
-        proxyPass = "http://${hosts.rho.wg-admin}:3000";
-        proxyWebsockets = true;
-        extraConfig = ''
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
-        '';
+  services.nginx = {
+    enable = true;
+
+    virtualHosts.${loggingDomain} = {
+      forceSSL = true;
+      sslCertificate = "${certDir}/fullchain.pem";
+      sslCertificateKey = "${certDir}/key.pem";
+
+      locations = authentikAuth.locations // {
+        "/" = {
+          proxyPass = "http://${currentHost.wg-admin}:3000";
+          extraConfig = authentikAuth.protectLocation + ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+        "/api/live/" = {
+          proxyPass = "http://${currentHost.wg-admin}:3000";
+          proxyWebsockets = true;
+          extraConfig = authentikAuth.protectLocation + ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
       };
     };
   };
 
-  security.acme.certs.${loggingDomain} = {
-    dnsProvider = "cloudflare";
-    environmentFile = config.sops.secrets.cloudflare-credentials.path;
-    group = "nginx";
-  };
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 443 ];
 }

--- a/modules/multievolve/default.nix
+++ b/modules/multievolve/default.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.networking.sbee) hosts;
+  authentikAuth = import ../authentik/nginx-locations.nix { inherit hosts; };
+  domain = "multievolve.sjanglab.org";
+  port = 8501;
+  certDir = "/var/lib/acme/${domain}";
+in
+{
+  imports = [
+    inputs.multievolve-nix.nixosModules.default
+    ../acme/sync.nix
+    ../gatus/check.nix
+  ];
+
+  gatusCheck.push = [
+    {
+      name = "MULTI-evolve";
+      group = "ai";
+      url = "http://127.0.0.1:${toString port}/_stcore/health";
+    }
+  ];
+
+  acmeSyncer.mkReceiver = [
+    {
+      inherit domain;
+      user = "acme-sync-multievolve";
+    }
+  ];
+
+  services.multievolve-streamlit = {
+    enable = true;
+    host = "127.0.0.1";
+    inherit port;
+    workingDirectory = "/workspace/multievolve";
+    extraGroups = [
+      "render"
+      "video"
+    ];
+    environment = {
+      CUDA_VISIBLE_DEVICES = "0";
+      LD_LIBRARY_PATH = lib.concatStringsSep ":" [
+        "/run/opengl-driver/lib"
+        "${pkgs.cudaPackages.cuda_cudart}/lib"
+        "${pkgs.cudaPackages.libcublas}/lib"
+      ];
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+
+    virtualHosts.${domain} = {
+      forceSSL = true;
+      sslCertificate = "${certDir}/fullchain.pem";
+      sslCertificateKey = "${certDir}/key.pem";
+
+      locations = authentikAuth.locations // {
+        "/" = {
+          proxyPass = "http://127.0.0.1:${toString port}";
+          proxyWebsockets = true;
+          extraConfig = authentikAuth.protectLocation + ''
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+            client_max_body_size 1G;
+          '';
+        };
+      };
+    };
+  };
+
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 443 ];
+}

--- a/modules/ollama/default.nix
+++ b/modules/ollama/default.nix
@@ -94,7 +94,8 @@ in
       sslCertificate = "${certDir}/fullchain.pem";
       sslCertificateKey = "${certDir}/key.pem";
 
-      # Access control: Headscale ACL (network-level, no forward auth)
+      # API clients do not handle browser redirects from Authentik forward auth.
+      # Keep application authorization in API credentials when this module is enabled.
       locations."/" = {
         proxyPass = "http://127.0.0.1:${toString port}";
         recommendedProxySettings = false; # Override Host header manually

--- a/modules/vaultwarden/default.nix
+++ b/modules/vaultwarden/default.nix
@@ -1,15 +1,13 @@
 { config, ... }:
 {
-  imports = [
-    ../acme
-    ../gatus/check.nix
-  ];
+  imports = [ ../gatus/check.nix ];
 
   gatusCheck.pull = [
     {
       name = "Vaultwarden";
-      url = "https://vault.sjanglab.org/alive";
+      url = "http://127.0.0.1:8000/alive";
       group = "apps";
+      conditions = [ "[STATUS] == 200" ];
     }
   ];
 
@@ -35,6 +33,7 @@
       # Organization
       ORG_CREATION_USERS = "sjang.bioe@gmail.com,admin@sjanglab.org";
 
+      ROCKET_ADDRESS = "0.0.0.0";
       ROCKET_PORT = 8000;
     };
   };
@@ -46,37 +45,9 @@
     mode = "0400";
   };
 
-  # ACME certificate (DNS challenge)
-  security.acme.certs."vault.sjanglab.org" = {
-    dnsProvider = "cloudflare";
-    environmentFile = config.sops.secrets.cloudflare-credentials.path;
-    webroot = null;
-    group = "nginx";
-  };
-
-  # Nginx reverse proxy
-  services.nginx.virtualHosts."vault.sjanglab.org" = {
-    forceSSL = true;
-    useACMEHost = "vault.sjanglab.org";
-
-    locations."/" = {
-      proxyPass = "http://127.0.0.1:8000";
-      proxyWebsockets = true;
-      extraConfig = ''
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-      '';
-    };
-  };
-
   systemd.tmpfiles.rules = [
     "d /var/backup/vaultwarden 0700 vaultwarden vaultwarden -"
   ];
 
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-  ];
+  networking.firewall.interfaces.wg-admin.allowedTCPPorts = [ 8000 ];
 }

--- a/modules/vaultwarden/reverse-proxy.nix
+++ b/modules/vaultwarden/reverse-proxy.nix
@@ -1,0 +1,40 @@
+# Vaultwarden tailnet reverse proxy (deployed on tau)
+{ config, ... }:
+let
+  inherit (config.networking.sbee) hosts;
+  domain = "vault.sjanglab.org";
+  certDir = "/var/lib/acme/${domain}";
+in
+{
+  imports = [ ../acme/sync.nix ];
+
+  acmeSyncer.mkReceiver = [
+    {
+      inherit domain;
+      user = "acme-sync-vaultwarden";
+    }
+  ];
+
+  services.nginx = {
+    enable = true;
+
+    virtualHosts.${domain} = {
+      forceSSL = true;
+      sslCertificate = "${certDir}/fullchain.pem";
+      sslCertificateKey = "${certDir}/key.pem";
+
+      locations."/" = {
+        proxyPass = "http://${hosts.eta.wg-admin}:8000";
+        proxyWebsockets = true;
+        extraConfig = ''
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        '';
+      };
+    };
+  };
+
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 443 ];
+}

--- a/modules/vllm/default.nix
+++ b/modules/vllm/default.nix
@@ -135,6 +135,8 @@ in
       sslCertificate = "/var/lib/acme/${domain}/fullchain.pem";
       sslCertificateKey = "/var/lib/acme/${domain}/key.pem";
 
+      # API clients do not handle browser redirects from Authentik forward auth.
+      # Keep application authorization in API credentials when this module is enabled.
       locations."/" = {
         proxyPass = "http://127.0.0.1:8100";
         extraConfig = ''

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -54,16 +54,6 @@ resource "cloudflare_dns_record" "buildbot" {
   comment = "Nixbot CI/CD edge proxy (eta -> psi)"
 }
 
-resource "cloudflare_dns_record" "s3" {
-  zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
-  name    = "s3.sjanglab.org"
-  content = "141.164.53.203"
-  type    = "A"
-  ttl     = 300
-  proxied = false
-  comment = "MinIO S3 API"
-}
-
 resource "cloudflare_dns_record" "ntfy" {
   zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
   name    = "ntfy.sjanglab.org"
@@ -72,16 +62,6 @@ resource "cloudflare_dns_record" "ntfy" {
   ttl     = 300
   proxied = false
   comment = "ntfy notification service"
-}
-
-resource "cloudflare_dns_record" "logging" {
-  zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
-  name    = "logging.sjanglab.org"
-  content = "141.164.53.203"
-  type    = "A"
-  ttl     = 300
-  proxied = false
-  comment = "Grafana logging dashboard"
 }
 
 resource "cloudflare_dns_record" "headscale" {
@@ -102,26 +82,6 @@ resource "cloudflare_dns_record" "authentik" {
   ttl     = 300
   proxied = false
   comment = "Authentik SSO server"
-}
-
-resource "cloudflare_dns_record" "vaultwarden" {
-  zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
-  name    = "vault.sjanglab.org"
-  content = "141.164.53.203"
-  type    = "A"
-  ttl     = 300
-  proxied = false
-  comment = "Vaultwarden password manager"
-}
-
-resource "cloudflare_dns_record" "gatus" {
-  zone_id = data.sops_file.secrets.data["CLOUDFLARE_ZONE_ID"]
-  name    = "gatus.sjanglab.org"
-  content = "141.164.53.203"
-  type    = "A"
-  ttl     = 300
-  proxied = false
-  comment = "Gatus status monitoring"
 }
 
 resource "cloudflare_dns_record" "n8n" {


### PR DESCRIPTION
Keep services that do not need public ingress off the public Cloudflare zone by moving Grafana, Gatus, Vaultwarden, and MULTI-evolve behind Headscale-resolved vhosts, with Authentik forward auth on browser dashboards and API services left dormant or token-oriented. This keeps external exposure limited to login, coordination, and webhook endpoints while preserving internal access over the tailnet. Verified with nix fmt, treefmt, and dry-run NixOS builds for eta, psi, rho, and tau.